### PR TITLE
Allow to disable -march=native from CMake

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -35,6 +35,7 @@ jobs:
           python -m build --sdist . --outdir dist
           python -m cibuildwheel dist/*.tar.gz --output-dir dist
         env:
+          CIBW_BUILD_VERBOSITY: 3
           # build wheels on CPython 3.10
           CIBW_BUILD: cp310-*
           # skip musl and 32-bit builds
@@ -42,6 +43,8 @@ jobs:
           # on macOS, build both Intel & Apple Silicon versions
           CIBW_ARCHS_MACOS: x86_64 arm64
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+          # do not build wheels with -march=native
+          CIBW_ENVIRONMENT: SPHERICART_ARCH_NATIVE=OFF
 
       - name: Build sphericart-torch wheels
         run: |
@@ -49,6 +52,7 @@ jobs:
           python -m build --sdist sphericart-torch --outdir sphericart-torch/dist
           python -m cibuildwheel sphericart-torch/dist/*.tar.gz --output-dir sphericart-torch/dist
         env:
+          CIBW_BUILD_VERBOSITY: 3
           CIBW_BUILD: cp310-*
           CIBW_SKIP: "*-musllinux* *-win32 *-manylinux_i686"
           # we can not build wheels for macos-arm64, since the host is always
@@ -56,7 +60,7 @@ jobs:
           CIBW_ARCHS_MACOS: x86_64
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           # Use the CPU only version of torch when building/running the code
-          CIBW_ENVIRONMENT: PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu
+          CIBW_ENVIRONMENT: SPHERICART_ARCH_NATIVE=OFF PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu
           # do not complain for missing libtorch.so in sphericart-torch wheel
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: |
             delocate-wheel --ignore-missing-dependencies --require-archs {delocate_archs} -w {dest_dir} -v {wheel}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DSPHERICART_BUILD_EXAMPLES=ON
+          cmake -DSPHERICART_BUILD_EXAMPLES=ON -DSPHERICART_BUILD_TESTS=ON ..
           cmake --build .
           ctest
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,16 @@ For instructions and examples on the usage of the library, please refer to our
 
 ### Python API
 
-From source
+Pre-built (https://pypi.org/project/sphericart/).
+
+```bash
+pip install sphericart             # numpy version
+pip install sphericart[torch]      # including also the torch bindings
+```
+
+Note that the pre-built packages are compiled for a generic CPU, and might be
+less performant than they could be on a specific processor. To generate
+libraries that are optimized for the target system, you can build from source:
 
 ```bash
 git clone https://github.com/lab-cosmo/sphericart
@@ -24,13 +33,6 @@ pip install .[torch]
 
 # torch bindings, CPU-only version
 pip install --extra-index-url https://download.pytorch.org/whl/cpu .[torch]
-```
-
-Pre-built (https://pypi.org/project/sphericart/).
-
-```bash
-pip install sphericart             # numpy version
-pip install sphericart[torch]      # including also the torch bindings
 ```
 
 ### C and C++ API
@@ -58,14 +60,18 @@ The following cmake configuration options are available:
 
 Tests and the local build of the documentation can be run with `tox`.
 The default tests, which are also run on the CI, can be executed by simply running
+
 ```bash
 tox
 ```
+
 in the main folder of the repository.
 
 To run tests in a CPU-only environment you can set the environment variable
 `PIP_EXTRA_INDEX_URL` before calling tox, e.g.
+
 ```bash
 PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu tox -e docs
 ```
+
 will build the documentation in a CPU-only environment.

--- a/docs/src/installation.rst
+++ b/docs/src/installation.rst
@@ -12,17 +12,30 @@ The Python package can be installed with pip by simply running
     pip install sphericart
 
 This basic package makes use of NumPy. A PyTorch-based implementation,
-which includes GPU support, can be installed with 
+which includes GPU support, can be installed with
 
 .. code-block:: bash
 
     pip install sphericart[torch]
 
+The pre-built version available on PyPI tradeoff some performance to ensure it
+will works on all systems. If you need an extra 5-10% of performance, you should
+build the code from source:
+
+.. code-block:: bash
+
+    git clone https://github.com/lab-cosmo/sphericart
+    pip install .
+
+    # if you also want the torch bindings
+    pip install .[torch]
+
+
 
 C/C++ library
 -------------
 
-First, the repository needs to be cloned with 
+First, the repository needs to be cloned with
 
 .. code-block:: bash
 
@@ -38,8 +51,8 @@ After that, default installation of the C/C++ library can be achieved as
     cmake ..
     make install
 
-This will attempt to install a static library inside the ``/usr/local/lib/`` folder, 
-which might cause a permission error. This can be solved by using 
-higher privileges (e.g., ``sudo make install``) or, alternatively, by changing the destination 
-folder. For example, ``cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/.local``
+This will attempt to install a static library inside the ``/usr/local/lib/``
+folder, which might cause a permission error. This can be solved by using higher
+privileges (e.g., ``sudo make install``) or, alternatively, by changing the
+destination folder. For example, ``cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/.local``
 will be appropriate in the majority of cases.

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ from wheel.bdist_wheel import bdist_wheel
 
 
 ROOT = os.path.realpath(os.path.dirname(__file__))
+SPHERICART_ARCH_NATIVE = os.environ.get("SPHERICART_ARCH_NATIVE", "ON")
 
 
 class universal_wheel(bdist_wheel):
@@ -38,7 +39,7 @@ class cmake_ext(build_ext):
         cmake_options = [
             f"-DCMAKE_INSTALL_PREFIX={install_dir}",
             "-DBUILD_SHARED_LIBS=ON",
-            "-DSPHERICART_BUILD_TESTS=OFF",
+            f"-DSPHERICART_ARCH_NATIVE={SPHERICART_ARCH_NATIVE}",
         ]
 
         if sys.platform.startswith("darwin"):

--- a/sphericart-torch/setup.py
+++ b/sphericart-torch/setup.py
@@ -8,6 +8,7 @@ from setuptools.command.build_ext import build_ext
 
 
 ROOT = os.path.realpath(os.path.dirname(__file__))
+SPHERICART_ARCH_NATIVE = os.environ.get("SPHERICART_ARCH_NATIVE", "ON")
 
 
 class cmake_ext(build_ext):
@@ -24,6 +25,7 @@ class cmake_ext(build_ext):
             f"-DCMAKE_INSTALL_PREFIX={install_dir}",
             "-DSPHERICART_TORCH_BUILD_FOR_PYTHON=ON",
             f"-DPYTHON_EXECUTABLE={sys.executable}",
+            f"-DSPHERICART_ARCH_NATIVE={SPHERICART_ARCH_NATIVE}",
         ]
 
         if sys.platform.startswith("darwin"):

--- a/sphericart/CMakeLists.txt
+++ b/sphericart/CMakeLists.txt
@@ -10,8 +10,9 @@ string(REGEX REPLACE "^[0-9]+\\.[0-9]+\\.([0-9]+).*" "\\1" SPHERICART_VERSION_PA
 
 option(BUILD_SHARED_LIBS "Build shared libraries instead of static ones" OFF)
 
-OPTION(SPHERICART_BUILD_TESTS "Build and run tests for Sphericart" ON) # TODO: change default to OFF
+OPTION(SPHERICART_BUILD_TESTS "Build and run tests for Sphericart" OFF)
 OPTION(SPHERICART_OPENMP "Try to use OpenMP when compiling Sphericart" ON)
+OPTION(SPHERICART_ARCH_NATIVE "Try to use -march=native when compiling Sphericart" ON)
 
 set(LIB_INSTALL_DIR "lib" CACHE PATH "Path relative to CMAKE_INSTALL_PREFIX where to install libraries")
 set(BIN_INSTALL_DIR "bin" CACHE PATH "Path relative to CMAKE_INSTALL_PREFIX where to install DLL/binaries")
@@ -84,12 +85,16 @@ else()
     endif()
 endif()
 
-check_cxx_compiler_flag("-march=native" COMPILER_SUPPORTS_MARCH_NATIVE)
-# for some reason COMPILER_SUPPORTS_MARCH_NATIVE is true with Apple clang,
-# but then fails with `the clang compiler does not support '-march=native'`
-if(COMPILER_SUPPORTS_MARCH_NATIVE AND NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    message(STATUS "march=native is enabled")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
+if (SPHERICART_ARCH_NATIVE)
+    check_cxx_compiler_flag("-march=native" COMPILER_SUPPORTS_MARCH_NATIVE)
+    # for some reason COMPILER_SUPPORTS_MARCH_NATIVE is true with Apple clang,
+    # but then fails with `the clang compiler does not support '-march=native'`
+    if(COMPILER_SUPPORTS_MARCH_NATIVE AND NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        message(STATUS "march=native is enabled")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
+    else()
+        message(STATUS "march=native is not supported by this compiler")
+    endif()
 endif()
 
 # handle warning flags


### PR DESCRIPTION
Use this when building wheels on CI to make sure the wheels will run on any system