### PR TITLE
Quickfix for hardcoded_sample

### DIFF
--- a/docs/src/maths.rst
+++ b/docs/src/maths.rst
@@ -13,7 +13,7 @@ possible to reformulate the spherical harmonics in a real-valued form, which lea
 to even further ambiguity in the definitions. 
 
 Within `sphericart` we take an opinionated stance: we compute only real-valued
-harmonics, we express them as a function of the full Cartesian cooedinates of a 
+harmonics, we express them as a function of the full Cartesian coordinates of a 
 point in three dimensions :math:`(x,y,z)` and compute by default "scaled" 
 versions :math:`\tilde{Y}^m_l(x)` which correspond to polynomials of the 
 Cartesian coordinates:

--- a/sphericart/include/templates.hpp
+++ b/sphericart/include/templates.hpp
@@ -91,8 +91,8 @@ void compute_sph_prefactors(int l_max, T *factors) {
 
 template <typename T, bool DO_DERIVATIVES, bool NORMALIZED, int HARDCODED_LMAX>
 inline void hardcoded_sph_sample(const T *xyz_i, T *sph_i, [[maybe_unused]] T *dsph_i,
-    int size_y,
     [[maybe_unused]] int l_max_dummy=0,  // dummy variables to have a uniform interface
+    [[maybe_unused]] int size_y=1,
     [[maybe_unused]] const T *py_dummy=nullptr,
     [[maybe_unused]] const T *qy_dummy=nullptr,
     [[maybe_unused]] T *c_dummy=nullptr,
@@ -163,7 +163,7 @@ void hardcoded_sph(const T *xyz, T *sph, [[maybe_unused]] T *dsph,
             if constexpr (DO_DERIVATIVES) {
                 dsph_i = dsph + i_sample * size_y * 3;
             }
-            hardcoded_sph_sample<T, DO_DERIVATIVES, NORMALIZED, HARDCODED_LMAX>(xyz_i, sph_i, dsph_i, size_y);
+            hardcoded_sph_sample<T, DO_DERIVATIVES, NORMALIZED, HARDCODED_LMAX>(xyz_i, sph_i, dsph_i, HARDCODED_LMAX, size_y);
         }
     }
 }

--- a/sphericart/tests/CMakeLists.txt
+++ b/sphericart/tests/CMakeLists.txt
@@ -2,4 +2,9 @@ add_executable(test_hardcoding test_hardcoding.cpp)
 target_link_libraries(test_hardcoding sphericart)
 target_compile_features(test_hardcoding PRIVATE cxx_std_17)
 
+add_executable(test_samples test_samples.cpp)
+target_link_libraries(test_samples sphericart)
+target_compile_features(test_samples PRIVATE cxx_std_17)
+
 add_test(NAME test_hardcoding COMMAND ./test_hardcoding)
+add_test(NAME test_samples COMMAND ./test_samples)

--- a/sphericart/tests/test_hardcoding.cpp
+++ b/sphericart/tests/test_hardcoding.cpp
@@ -104,6 +104,9 @@ int main(int argc, char *argv[]) {
     }
     if (test_passed) {
         printf("Consistency test passed\n");
+        return 0;
+    } else {
+        printf("Consistency test failed\n");
+        return -1;
     }
-    return 0;
 }

--- a/sphericart/tests/test_samples.cpp
+++ b/sphericart/tests/test_samples.cpp
@@ -1,0 +1,76 @@
+/** @file test_hardcoding.cpp
+ *  @brief Checks consistency of generic and hardcoded implementations
+*/
+
+#include <unistd.h>
+#include <sys/time.h>
+
+#include <cmath>
+#include <chrono>
+#include <iostream>
+
+#define _SPHERICART_INTERNAL_IMPLEMENTATION
+#include "sphericart.hpp"
+
+#define _SPH_TOL 1e-9
+#define DTYPE double
+using namespace sphericart;
+
+int main([[maybe_unused]] int argc, [[maybe_unused]] char *argv[]) {
+    size_t MAX_L_VALUE = 10;
+    
+    size_t n_samples = 2;
+    auto xyz_sample = std::vector<DTYPE>({1.,2.,3.});
+    auto xyz = std::vector<DTYPE>(n_samples*3, 0.0);
+    for (size_t i=0; i<n_samples*3; i+=3) {
+        xyz[i] = xyz_sample[0];
+        xyz[i+1] = xyz_sample[1];
+        xyz[i+2] = xyz_sample[2];
+    }
+
+    bool test_passed = true;
+    for (size_t l_max=0; l_max<=MAX_L_VALUE; l_max++) {
+        auto sph = std::vector<DTYPE>(n_samples*(l_max+1)*(l_max+1), 0.0);
+        auto dsph = std::vector<DTYPE>(n_samples*3*(l_max+1)*(l_max+1), 0.0);
+        auto sph_sample = std::vector<DTYPE>(1*(l_max+1)*(l_max+1), 0.0);
+        auto dsph_sample = std::vector<DTYPE>(1*3*(l_max+1)*(l_max+1), 0.0);
+        SphericalHarmonics<DTYPE> SH(l_max, false);
+        SH.compute_with_gradients(xyz_sample, sph_sample, dsph_sample);
+        SH.compute_with_gradients(xyz, sph, dsph);
+        int size3 = 3*(l_max+1)*(l_max+1);  // Size of the third dimension in derivative arrays (or second in normal sph arrays).
+        int size2 = (l_max+1)*(l_max+1);  // Size of the second+third dimensions in derivative arrays    
+        for (size_t i_sample=0; i_sample<n_samples; i_sample++) {
+            for (size_t l=0; l<(l_max+1); l++) {
+                for (int m=-static_cast<int>(l); m<=static_cast<int>(l); m++) {
+                    if (fabs(sph[size2*i_sample+l*l+l+m]/sph_sample[l*l+l+m]-1)>_SPH_TOL) {
+                        printf("Mismatch detected at i_sample = %zu, L = %zu, m = %d \n", i_sample, l, m);
+                        printf("SPH: %e, %e\n", sph[size2*i_sample+l*l+l+m], sph_sample[l*l+l+m]);
+                        test_passed = false;
+                    }
+                    if (fabs(dsph[size3*i_sample+size2*0+l*l+l+m]/dsph_sample[size2*0+l*l+l+m]-1)>_SPH_TOL) {
+                        printf("Mismatch detected at i_sample = %zu, L = %zu, m = %d \n", i_sample, l, m);
+                        printf("DxSPH: %e, %e\n", dsph[size3*i_sample+size2*0+l*l+l+m], dsph_sample[size2*0+l*l+l+m]);
+                        test_passed = false;
+                    }
+                    if (fabs(dsph[size3*i_sample+size2*1+l*l+l+m]/dsph_sample[size2*1+l*l+l+m]-1)>_SPH_TOL) {
+                        printf("Mismatch detected at i_sample = %zu, L = %zu, m = %d \n", i_sample, l, m);
+                        printf("DySPH: %e, %e\n", dsph[size3*i_sample+size2*1+l*l+l+m], dsph_sample[size2*1+l*l+l+m]);
+                        test_passed = false;
+                    }
+                    if (fabs(dsph[size3*i_sample+size2*2+l*l+l+m]/dsph_sample[size2*2+l*l+l+m]-1)>_SPH_TOL) {
+                        printf("Mismatch detected at i_sample = %zu, L = %zu, m = %d \n", i_sample, l, m);
+                        printf("DzSPH: %e, %e\n", dsph[size3*i_sample+size2*1+l*l+l+m], dsph_sample[size2*2+l*l+l+m]);
+                        test_passed = false;
+                    }                    
+                }
+            }
+        }
+    }
+    if (test_passed) {
+        printf("Consistency test passed\n");
+        return 0;
+    } else {
+        printf("Consistency test failed\n");
+        return -1;
+    }
+}


### PR DESCRIPTION
Fixes #39, which was due to the inconsistent order of parameters in `hardcoded_sph_sample`. 
Will also add a test for the consistency of array and sample calls so that this does not happen again, given that we don't use the direct sample calls that much.  