### PR TITLE
Improving the developer comments in the C++ implementation

### DIFF
--- a/sphericart/include/macros.hpp
+++ b/sphericart/include/macros.hpp
@@ -8,14 +8,20 @@
     values are computed for one point at a time, and that the spherical harmonics are
     stored in a contiguous section that "flattens" the (l,m) dimensions, e.g.
     [ (0,0), (1,-1), (1,0), (1,1), (2,-2), ...]
+
     Functions get pointers to the beginning of the storage space for the current sample,
     x,y,z and, for l>1, x^2, y^2 and z^2, which can be reused.
+    
     Each macro computes one l, and macros should be called in order as the higher l
     reuse calculations at lower angular momentum. The expressions here are derived
     with computer assisted algebra by attempting all possible polynomial decompositions
-    and selecting that with the smallest number of operations.
+    and selecting that with the smallest number of operations. One should call
+    COMPUTE_SPH_L* or COMPUTE_SPH_DERIVATIVE_L* depending on whether only Ylm are needed
+    or if one also want to evbaluate Cartesian derivatives
 */
 
+// this is used thoughout to indicate the maximum l channel for which we provide a hard-coded macro.
+// this should be modified if further macros are added
 #define SPHERICART_LMAX_HARDCODED 6
 
 // we need this monstruosity to make sure that literals are not treated as 
@@ -297,8 +303,8 @@
     }
 
 /*
-Combines the macro hard-coded Ylm calculators to get all the terms
-up to a given value. Macro version.
+Combines the macro hard-coded Ylm calculators to get all the terms up to a given value. Macro version.
+This uses if constexpr to decide at compile time which macro(s) should be called
 */
 #define HARDCODED_SPH_MACRO(HARDCODED_LMAX, x, y, z, x2, y2, z2, sph_i, SPH_IDX) \
     static_assert(HARDCODED_LMAX <= SPHERICART_LMAX_HARDCODED, "Computing hardcoded sph beyond what is currently implemented."); \

--- a/sphericart/include/macros.hpp
+++ b/sphericart/include/macros.hpp
@@ -18,6 +18,10 @@
     and selecting that with the smallest number of operations. One should call
     COMPUTE_SPH_L* or COMPUTE_SPH_DERIVATIVE_L* depending on whether only Ylm are needed
     or if one also want to evbaluate Cartesian derivatives
+
+    Every macro takes an agument SPH_IDX that is an indexing function, that can be used to 
+    map the consecutive indices of the Ylm to a different memory layout (this is e.g. used
+    to optimize threads in CUDA code)
 */
 
 // this is used thoughout to indicate the maximum l channel for which we provide a hard-coded macro.

--- a/sphericart/include/sphericart.hpp
+++ b/sphericart/include/sphericart.hpp
@@ -184,19 +184,21 @@ public:
 
 /* @cond */
 private:
-    size_t l_max;
-    size_t size_y;
-    size_t size_q;
-    bool normalized;
-    int omp_num_threads;
-    T *prefactors;
+    size_t l_max; // maximum l value computed by this class
+    size_t size_y; // size of the Ylm rows (l_max+1)**2
+    size_t size_q; // size of the prefactor-like arrays (l_max+1)*(l_max+2)/2
+    bool normalized; // should we normalize the input vectors?
+    int omp_num_threads; // number of openmp thread
+    T *prefactors; // storage space for prefactor and buffers
     T *buffers;
 
     // function pointers are used to set up the right functions to be called
+    // these are set in the constructor, so that the public compute functions can 
+    // be redirected to the right implementation
     void (*_array_no_derivatives)(const T*, T*, T*, int, int, const T*, T*);
     void (*_array_with_derivatives)(const T*, T*, T*, int, int, const T*, T*);
-    // these compute a single sample
 
+    // these compute a single sample
     void (*_sample_no_derivatives)(const T*, T*, T*, int, int, const T*, const T*, T*, T*, T*);
     void (*_sample_with_derivatives)(const T*, T*, T*, int, int, const T*, const T*, T*, T*, T*);
 /* @endcond */

--- a/sphericart/src/sphericart.cpp
+++ b/sphericart/src/sphericart.cpp
@@ -6,7 +6,9 @@
 
 using namespace sphericart;
 
-// macro to define different possible hardcoded function calls
+// This macro to define different possible hardcoded function calls. It is used to 
+// initialize the function pointers that are used by the `compute_` calls in the
+// SphericalHarmonics class
 #define _HARCODED_SWITCH_CASE(L_MAX) \
     if (this->normalized) { \
         this->_array_no_derivatives = &hardcoded_sph<T, false, true, L_MAX>; \
@@ -22,11 +24,17 @@ using namespace sphericart;
 
 template<typename T>
 SphericalHarmonics<T>::SphericalHarmonics(size_t l_max, bool normalized) {
+    /* 
+        This is the constructor of the SphericalHarmonics class. It initizlizes buffer         
+        space, compute prefactors, and sets the function pointers that are used for 
+        the actual calls 
+    */
+
     this->l_max = (int) l_max;
     this->size_y = (int) (l_max + 1) * (l_max + 1);
     this->size_q = (int) (l_max + 1) * (l_max + 2) / 2;
     this->normalized = normalized;
-    this->prefactors = new T[(l_max+1)*(l_max+2)];
+    this->prefactors = new T[this->size_q*2];
     this ->omp_num_threads = omp_get_max_threads();
     
     // buffers for cos, sin, 2mz arrays
@@ -37,6 +45,8 @@ SphericalHarmonics<T>::SphericalHarmonics(size_t l_max, bool normalized) {
 
     // sets the correct function pointers for the compute functions
     if (this->l_max<=SPHERICART_LMAX_HARDCODED) {
+        // If we only need hard-coded calls, we set them up at this point
+        // using a macro to avoid even more code duplication. 
         switch (this->l_max) {
         case 0:
             _HARCODED_SWITCH_CASE(0);
@@ -77,12 +87,16 @@ SphericalHarmonics<T>::SphericalHarmonics(size_t l_max, bool normalized) {
 
 template<typename T>
 SphericalHarmonics<T>::~SphericalHarmonics() {
+    // Destructor, simply frees buffers
     delete [] this->prefactors;
     delete [] this->buffers;
 }
 
+// The compute/compute_with_gradient functions decide which function to call based on the size of the input vectors
+
 template<typename T>
-void SphericalHarmonics<T>::compute(const std::vector<T>& xyz, std::vector<T>& sph) {
+void SphericalHarmonics<T>::compute(const std::vector<T>& xyz, std::vector<T>& sph) {    
+
     auto n_samples = xyz.size() / 3;
     sph.resize(n_samples * (l_max + 1) * (l_max + 1));
 
@@ -106,6 +120,8 @@ void SphericalHarmonics<T>::compute_with_gradients(const std::vector<T>& xyz, st
     }
 }
 
+// Lower-level functions are simply wrappers over function-pointer-style calls that invoke the right (hardcoded or generic)
+// C++-library call
 template<typename T>
 void SphericalHarmonics<T>::compute_array(const T* xyz, size_t xyz_length, T* sph, size_t sph_length) {
     if (xyz_length % 3 != 0) {

--- a/sphericart/tests/test_hardcoding.cpp
+++ b/sphericart/tests/test_hardcoding.cpp
@@ -57,6 +57,7 @@ int main(int argc, char *argv[]) {
     auto prefactors = std::vector<DTYPE>((l_max+1)*(l_max+2), 0.0);
     compute_sph_prefactors(l_max, prefactors.data());
 
+    // random values
     auto xyz = std::vector<DTYPE>(n_samples*3, 0.0);
     for (size_t i=0; i<n_samples*3; ++i) {
         xyz[i] = (DTYPE)rand()/ (DTYPE) RAND_MAX *2.0-1.0;

--- a/sphericart/tests/test_samples.cpp
+++ b/sphericart/tests/test_samples.cpp
@@ -1,5 +1,5 @@
 /** @file test_hardcoding.cpp
- *  @brief Checks consistency of generic and hardcoded implementations
+ *  @brief Checks consistency of array and sample calls
 */
 
 #include <unistd.h>


### PR DESCRIPTION
In this PR I try to address some concerns on the fact that the C++ core is kind of impenetrable. I added throughout comments explaining what is done and why. Is there anything else that would be useful to do while I've all the C++ files open? 