### PR TITLE
CUDA backward bug

### DIFF
--- a/sphericart-torch/python/tests/test_nn.py
+++ b/sphericart-torch/python/tests/test_nn.py
@@ -41,7 +41,9 @@ def test_nn():
     if torch.cuda.is_available():
         nn = NN().to("cuda")
         energy, forces = nn(xyz.detach().to("cuda"))
-        loss = (target.to("cuda") - energy) ** 2 + torch.sum((d_target.to("cuda") - forces) ** 2)
+        loss = (target.to("cuda") - energy) ** 2 + torch.sum(
+            (d_target.to("cuda") - forces) ** 2
+        )
         loss.backward()
 
 

--- a/sphericart-torch/src/autograd.cpp
+++ b/sphericart-torch/src/autograd.cpp
@@ -284,8 +284,6 @@ torch::autograd::variable_list SphericalHarmonicsAutograd::forward(
         sph = results[0];
         dsph = results[1];
         ddsph = results[2];
-        // if (!(do_gradients || xyz.requires_grad())) dsph = torch::Tensor();
-        // if (!(do_hessians || (xyz.requires_grad() && calculator.backward_second_derivatives_))) ddsph = torch::Tensor();
     } else {
         throw std::runtime_error("Spherical harmonics are only implemented for CPU and CUDA");
     }

--- a/sphericart-torch/src/autograd.cpp
+++ b/sphericart-torch/src/autograd.cpp
@@ -284,8 +284,8 @@ torch::autograd::variable_list SphericalHarmonicsAutograd::forward(
         sph = results[0];
         dsph = results[1];
         ddsph = results[2];
-        if (!(do_gradients || xyz.requires_grad())) dsph = torch::Tensor();
-        if (!(do_hessians || (xyz.requires_grad() && calculator.backward_second_derivatives_))) ddsph = torch::Tensor();
+        // if (!(do_gradients || xyz.requires_grad())) dsph = torch::Tensor();
+        // if (!(do_hessians || (xyz.requires_grad() && calculator.backward_second_derivatives_))) ddsph = torch::Tensor();
     } else {
         throw std::runtime_error("Spherical harmonics are only implemented for CPU and CUDA");
     }

--- a/sphericart-torch/src/autograd.cpp
+++ b/sphericart-torch/src/autograd.cpp
@@ -221,11 +221,6 @@ torch::autograd::variable_list SphericalHarmonicsAutograd::forward(
         dsph = results[1];
         ddsph = results[2];
     } else if (xyz.device().is_cuda()) {
-        if (do_hessians || (xyz.requires_grad() && calculator.backward_second_derivatives_)) {
-            //TODO commenting this out so the CUDA code can be called for double backwards/hessians...
-           // throw std::runtime_error("Second derivatives are not yet implemented in CUDA");
-        }
-
         // re-do the shared memory update in case `requires_grad` changed        
         const std::lock_guard<std::mutex> guard(calculator.cuda_shmem_mutex_);
 
@@ -289,6 +284,8 @@ torch::autograd::variable_list SphericalHarmonicsAutograd::forward(
         sph = results[0];
         dsph = results[1];
         ddsph = results[2];
+        if (!(do_gradients || xyz.requires_grad())) dsph = torch::Tensor();
+        if (!(do_hessians || (xyz.requires_grad() && calculator.backward_second_derivatives_))) ddsph = torch::Tensor();
     } else {
         throw std::runtime_error("Spherical harmonics are only implemented for CPU and CUDA");
     }

--- a/sphericart-torch/src/cuda.cu
+++ b/sphericart-torch/src/cuda.cu
@@ -729,7 +729,7 @@ std::vector<torch::Tensor> sphericart_torch::spherical_harmonics_cuda(
     }
     else
     {
-        // just so accessor doesn't complain
+        // just so accessor doesn't complain (will be reverted later)
         d_sph = torch::empty(
             {1, 1, 1},
             torch::TensorOptions().dtype(xyz.dtype()).device(xyz.device()));
@@ -745,6 +745,7 @@ std::vector<torch::Tensor> sphericart_torch::spherical_harmonics_cuda(
     }
     else
     {
+        // just so accessor doesn't complain (will be reverted later)
         hess_sph = torch::empty(
             {1, 1, 1, 1},
             torch::TensorOptions().dtype(xyz.dtype()).device(xyz.device()));
@@ -779,6 +780,8 @@ std::vector<torch::Tensor> sphericart_torch::spherical_harmonics_cuda(
 
     cudaDeviceSynchronize();
 
+    if (!gradients) d_sph = torch::Tensor();
+    if (!hessian) hess_sph = torch::Tensor();
     return {sph, d_sph, hess_sph};
 }
 


### PR DESCRIPTION
At the moment, we decide whether to calculate double backward second derivatives by checking if `ddsph` is defined or not. This is fine for the CPU code, but on the CUDA code `dsph` and `ddsph` are defined also if these are not required. This leads to second derivatives of the wrong shape which cause torch to crash later on 