### PR TITLE
Added caching of the sphericart class

### DIFF
--- a/benchmarks/jax/benchmark.py
+++ b/benchmarks/jax/benchmark.py
@@ -1,7 +1,7 @@
 import argparse
 import time
 
-import numpy as np 
+import numpy as np
 
 import jax
 import sphericart.jax
@@ -45,11 +45,11 @@ def sphericart_benchmark(
         f"**** Timings for l_max={l_max}, n_samples={n_samples}, n_tries={n_tries}, "
         + f"dtype={dtype} ****"
     )
-    
+
     time_noderi = np.zeros(n_tries + warmup)
     time_fw = np.zeros(n_tries + warmup)
     time_bw = np.zeros(n_tries + warmup)
-    
+
     for i in range(n_tries + warmup):
         elapsed = -time.time()
         sh_sphericart = sh_calculator(xyz, l_max, normalized)
@@ -84,7 +84,7 @@ def sphericart_benchmark(
 
     def scalar_output(xyz, l_max, normalized):
         return jax.numpy.sum(sphericart.jax.spherical_harmonics(xyz, l_max, normalized))
-    
+
     sh_grad = jax.jit(jax.grad(scalar_output), static_argnums=1)
 
     time_deri = np.zeros(n_tries + warmup)
@@ -103,14 +103,16 @@ def sphericart_benchmark(
     if verbose:
         print("Warm-up timings / sec.:\n", time_deri[:warmup])
 
-    def single_scalar_output(x, l_max, normalized):        
+    def single_scalar_output(x, l_max, normalized):
         return jax.numpy.sum(sphericart.jax.spherical_harmonics(x, l_max, normalized))
 
     # Compute the Hessian for a single (3,) input
     single_hessian = jax.hessian(single_scalar_output)
 
     # Use vmap to vectorize the Hessian computation over the first axis
-    sh_hess = jax.jit(jax.vmap(single_hessian, in_axes=(0, None, None)), static_argnums=1)
+    sh_hess = jax.jit(
+        jax.vmap(single_hessian, in_axes=(0, None, None)), static_argnums=1
+    )
 
     time_deri = np.zeros(n_tries + warmup)
     for i in range(n_tries + warmup):
@@ -121,7 +123,7 @@ def sphericart_benchmark(
 
     mean_time = time_deri[warmup:].mean() / n_samples
     std_time = time_deri[warmup:].std() / n_samples
-    print(  
+    print(
         f" Hessian (scalar, jit):    {mean_time * 1e9:10.1f} ns/sample ± "
         + f"{std_time * 1e9:10.1f} (std)"
     )
@@ -136,7 +138,6 @@ def sphericart_benchmark(
             sphericart.jax.spherical_harmonics(xyz, l_max, normalized), axis=0
         )
 
-
     jacfwd = jax.jit(jax.jacfwd(array_output), static_argnums=1)
 
     time_deri = np.zeros(n_tries + warmup)
@@ -148,7 +149,7 @@ def sphericart_benchmark(
 
     mean_time = time_deri[warmup:].mean() / n_samples
     std_time = time_deri[warmup:].std() / n_samples
-    print(  
+    print(
         f" jacfwd (jit):    {mean_time * 1e9:10.1f} ns/sample ± "
         + f"{std_time * 1e9:10.1f} (std)"
     )
@@ -166,7 +167,7 @@ def sphericart_benchmark(
 
     mean_time = time_deri[warmup:].mean() / n_samples
     std_time = time_deri[warmup:].std() / n_samples
-    print(  
+    print(
         f" jacrev (jit):    {mean_time * 1e9:10.1f} ns/sample ± "
         + f"{std_time * 1e9:10.1f} (std)"
     )

--- a/benchmarks/jax/benchmark.py
+++ b/benchmarks/jax/benchmark.py
@@ -1,0 +1,194 @@
+import argparse
+import time
+
+import numpy as np 
+
+import jax
+import sphericart.jax
+
+jax.config.update("jax_enable_x64", True)  # enable float64 for jax
+
+docstring = """
+Benchmarks for the jax implementation of `sphericart`.
+
+Compares with e3nn_jax if present and if the comparison is requested.
+"""
+
+try:
+    import e3nn_jax
+    import jax.numpy as jnp
+
+    _HAS_E3NN_JAX = True
+except ImportError:
+    _HAS_E3NN_JAX = False
+
+
+def sphericart_benchmark(
+    l_max=10,
+    n_samples=10000,
+    n_tries=100,
+    normalized=False,
+    device="cpu",
+    dtype=np.float64,
+    compare=False,
+    verbose=False,
+    warmup=16,
+):
+    key = jax.random.PRNGKey(0)
+    xyz = jax.random.normal(key, (n_samples, 3), dtype=dtype)
+
+    sh_calculator = sphericart.jax.spherical_harmonics
+
+    sh_calculator_jit = jax.jit(sphericart.jax.spherical_harmonics, static_argnums=1)
+
+    print(
+        f"**** Timings for l_max={l_max}, n_samples={n_samples}, n_tries={n_tries}, "
+        + f"dtype={dtype} ****"
+    )
+    
+    time_noderi = np.zeros(n_tries + warmup)
+    time_fw = np.zeros(n_tries + warmup)
+    time_bw = np.zeros(n_tries + warmup)
+    
+    for i in range(n_tries + warmup):
+        elapsed = -time.time()
+        sh_sphericart = sh_calculator(xyz, l_max, normalized)
+        elapsed += time.time()
+        time_noderi[i] = elapsed
+
+    mean_time = time_noderi[warmup:].mean() / n_samples
+    std_time = time_noderi[warmup:].std() / n_samples
+    print(
+        f" No derivatives: {mean_time * 1e9: 10.1f} ns/sample ± "
+        + f"{std_time * 1e9: 10.1f} (std)"
+    )
+    if verbose:
+        print("Warm-up timings / sec.:\n", time_noderi[:warmup])
+
+    time_noderi[:] = 0.0
+
+    for i in range(n_tries + warmup):
+        elapsed = -time.time()
+        sh_sphericart_jit = sh_calculator_jit(xyz, l_max, normalized)
+        elapsed += time.time()
+        time_noderi[i] = elapsed
+
+    mean_time = time_noderi[warmup:].mean() / n_samples
+    std_time = time_noderi[warmup:].std() / n_samples
+    print(
+        f" No derivatives, jit: {mean_time * 1e9: 10.1f} ns/sample ± "
+        + f"{std_time * 1e9: 10.1f} (std)"
+    )
+    if verbose:
+        print("Warm-up timings / sec.:\n", time_noderi[:warmup])
+
+
+    if compare and _HAS_E3NN_JAX:
+        xyz_tensor = xyz.copy()
+
+        irreps = e3nn_jax.Irreps([e3nn_jax.Irrep(l, 1) for l in range(l_max + 1)])
+
+        def loss_fn(xyz_tensor):
+            sh_e3nn = e3nn_jax.spherical_harmonics(
+                irreps, xyz_tensor, normalize=normalized, normalization="integral"
+            )
+            loss = jnp.sum(sh_e3nn.array)
+            return loss
+
+        loss_grad_fn = jax.grad(loss_fn)
+
+        for i in range(n_tries + warmup):
+            elapsed = -time.time()
+            _ = loss_fn(xyz_tensor)
+            elapsed += time.time()
+            time_fw[i] = elapsed
+
+            elapsed = -time.time()
+            _ = loss_grad_fn(xyz_tensor)
+            elapsed += time.time()
+            time_bw[i] = elapsed
+
+        mean_time = time_fw[warmup:].mean() / n_samples
+        std_time = time_fw[warmup:].std() / n_samples
+        print(
+            f" E3NN-JAX-FW:    {mean_time*1e9: 10.1f} ns/sample ± "
+            + f"{std_time*1e9: 10.1f} (std)"
+        )
+        if verbose:
+            print("Warm-up timings / sec.: \n", time_fw[:warmup])
+        mean_time = time_bw[warmup:].mean() / n_samples
+        std_time = time_bw[warmup:].std() / n_samples
+        print(
+            f" E3NN-JAX-BW:    {mean_time*1e9: 10.1f} ns/sample ± "
+            + f"{std_time*1e9: 10.1f} (std)"
+        )
+        if verbose:
+            print("Warm-up timings / sec.: \n", time_bw[:warmup])
+    print(
+        "******************************************************************************"
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=docstring)
+
+    parser.add_argument("-l", type=int, default=10, help="maximum angular momentum")
+    parser.add_argument("-s", type=int, default=10000, help="number of samples")
+    parser.add_argument("-t", type=int, default=100, help="number of runs/sample")
+    parser.add_argument(
+        "-cpu", type=int, default=1, help="print CPU results (0=False, 1=True)"
+    )
+    parser.add_argument(
+        "-gpu", type=int, default=0, help="print GPU results (0=False, 1=True)"
+    )
+    parser.add_argument(
+        "--normalized",
+        action="store_true",
+        default=False,
+        help="compute normalized spherical harmonics",
+    )
+    parser.add_argument(
+        "--compare",
+        action="store_true",
+        default=False,
+        help="compare timings with other codes, if installed",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        default=False,
+        help="verbose timing output",
+    )
+    parser.add_argument(
+        "--warmup", type=int, default=16, help="number of warm-up evaluations"
+    )
+
+    args = parser.parse_args()
+
+    # Run benchmarks
+    if args.cpu:
+        sphericart_benchmark(
+            args.l,
+            args.s,
+            args.t,
+            args.normalized,
+            device="cpu",
+            dtype=np.float64,
+            compare=args.compare,
+            verbose=args.verbose,
+            warmup=args.warmup,
+        )
+        sphericart_benchmark(
+            args.l,
+            args.s,
+            args.t,
+            args.normalized,
+            device="cpu",
+            dtype=np.float32,
+            compare=args.compare,
+            verbose=args.verbose,
+            warmup=args.warmup,
+        )
+
+    if args.gpu:
+        raise ValueError("GPU implementation of sphericart-jax is not yet available")

--- a/examples/jax/example.py
+++ b/examples/jax/example.py
@@ -30,20 +30,23 @@ def scalar_output(xyz, l_max, normalized):
 grad = jax.grad(scalar_output)(xyz, l_max, normalized)
 
 # NB: this computes a (n_samples,3,n_samples,3) hessian, i.e. includes cross terms
-# between samples. 
+# between samples.
 hessian = jax.hessian(scalar_output)(xyz, l_max, normalized)
 
-# usually you want a (n_samples,3,3), taking derivatives wrt the coordinates 
+# usually you want a (n_samples,3,3), taking derivatives wrt the coordinates
 # of the same sample. one way to achieve this is as follows
 
-def single_scalar_output(xyz, l_max, normalized):        
+
+def single_scalar_output(xyz, l_max, normalized):
     return jax.numpy.sum(sphericart.jax.spherical_harmonics(xyz, l_max, normalized))
+
 
 # Compute the Hessian for a single (3,) input
 single_hessian = jax.hessian(single_scalar_output)
 
 # Use vmap to vectorize the Hessian computation over the first axis
 sh_hess = jax.vmap(single_hessian, in_axes=(0, None, None))
+
 
 # calculate a function of the spherical harmonics that returns an array
 # and take its jacobian with respect to the input Cartesian coordinates,

--- a/examples/jax/example.py
+++ b/examples/jax/example.py
@@ -28,8 +28,22 @@ def scalar_output(xyz, l_max, normalized):
 
 
 grad = jax.grad(scalar_output)(xyz, l_max, normalized)
+
+# NB: this computes a (n_samples,3,n_samples,3) hessian, i.e. includes cross terms
+# between samples. 
 hessian = jax.hessian(scalar_output)(xyz, l_max, normalized)
 
+# usually you want a (n_samples,3,3), taking derivatives wrt the coordinates 
+# of the same sample. one way to achieve this is as follows
+
+def single_scalar_output(xyz, l_max, normalized):        
+    return jax.numpy.sum(sphericart.jax.spherical_harmonics(xyz, l_max, normalized))
+
+# Compute the Hessian for a single (3,) input
+single_hessian = jax.hessian(single_scalar_output)
+
+# Use vmap to vectorize the Hessian computation over the first axis
+sh_hess = jax.vmap(single_hessian, in_axes=(0, None, None))
 
 # calculate a function of the spherical harmonics that returns an array
 # and take its jacobian with respect to the input Cartesian coordinates,

--- a/sphericart-jax/python/sphericart/jax/ddsph.py
+++ b/sphericart-jax/python/sphericart/jax/ddsph.py
@@ -80,5 +80,5 @@ def ddsph_p_batch(arg_values, batch_axes, *, l_max_c):
     res = ddsph(*arg_values)
     return res, (batch_axes[0], batch_axes[0], batch_axes[0])
 
-  
+
 jax.interpreters.batching.primitive_batchers[_ddsph_p] = ddsph_p_batch

--- a/sphericart-jax/python/sphericart/jax/dsph.py
+++ b/sphericart-jax/python/sphericart/jax/dsph.py
@@ -76,7 +76,7 @@ mlir.register_lowering(_dsph_p, dsph_lowering_cpu, platform="cpu")
 def dsph_p_batch(arg_values, batch_axes, *, l_max_c):
     res = dsph(*arg_values)
     return res, (batch_axes[0], batch_axes[0])
-  
+
 
 jax.interpreters.batching.primitive_batchers[_dsph_p] = dsph_p_batch
 

--- a/sphericart-jax/python/tests/test_transforms.py
+++ b/sphericart-jax/python/tests/test_transforms.py
@@ -64,11 +64,12 @@ def test_hessian_jit(xyz):
     for l_max in [4, 7, 10]:
         for normalized in [True, False]:
             sph = transformed_sph(xyz, l_max, normalized)
-            
-            
+
+
 def test_vmap_grad(xyz):
-    def single_scalar_output(x, l_max, normalized):        
+    def single_scalar_output(x, l_max, normalized):
         return jax.numpy.sum(sphericart.jax.spherical_harmonics(x, l_max, normalized))
+
     single_grad = jax.grad(single_scalar_output)
     sh_grad = jax.vmap(single_grad, in_axes=(0, None, None), out_axes=0)
     for l_max in [4, 7, 10]:
@@ -77,8 +78,9 @@ def test_vmap_grad(xyz):
 
 
 def test_vmap_hessian(xyz):
-    def single_scalar_output(x, l_max, normalized):        
+    def single_scalar_output(x, l_max, normalized):
         return jax.numpy.sum(sphericart.jax.spherical_harmonics(x, l_max, normalized))
+
     single_hessian = jax.hessian(single_scalar_output)
     sh_hessian = jax.vmap(single_hessian, in_axes=(0, None, None), out_axes=0)
     for l_max in [4, 7, 10]:

--- a/sphericart-jax/src/jax.cpp
+++ b/sphericart-jax/src/jax.cpp
@@ -15,18 +15,24 @@ using namespace sphericart_jax;
 
 namespace {
 
-template<typename T> 
-using CacheMap = std::map<std::tuple<size_t, bool>, std::unique_ptr<sphericart::SphericalHarmonics<T>>>;
+template <typename T>
+using CacheMap = std::map<std::tuple<size_t, bool>,
+                          std::unique_ptr<sphericart::SphericalHarmonics<T>>>;
 
-template <typename T> std::unique_ptr<sphericart::SphericalHarmonics<T>>&
-    _get_or_create_sph(CacheMap<T>& sph_cache , std::mutex& cache_mutex,
-        size_t l_max, bool normalized  ) {
-    // Check if instance exists in cache, if not create and store it    
+template <typename T>
+std::unique_ptr<sphericart::SphericalHarmonics<T>> &
+_get_or_create_sph(CacheMap<T> &sph_cache, std::mutex &cache_mutex,
+                   size_t l_max, bool normalized) {
+    // Check if instance exists in cache, if not create and store it
     std::lock_guard<std::mutex> lock(cache_mutex);
     auto key = std::make_tuple(l_max, normalized);
     auto it = sph_cache.find(key);
     if (it == sph_cache.end()) {
-        it = sph_cache.insert({key,std::make_unique<sphericart::SphericalHarmonics<T>>(l_max, normalized)}).first;            
+        it = sph_cache
+                 .insert(
+                     {key, std::make_unique<sphericart::SphericalHarmonics<T>>(
+                               l_max, normalized)})
+                 .first;
     }
     return it->second;
 }
@@ -46,7 +52,8 @@ template <typename T> void cpu_sph(void *out, const void **in) {
     static CacheMap<T> sph_cache;
     static std::mutex cache_mutex;
 
-    auto& calculator = _get_or_create_sph(sph_cache, cache_mutex, l_max, normalized);
+    auto &calculator =
+        _get_or_create_sph(sph_cache, cache_mutex, l_max, normalized);
     calculator->compute_array(xyz, xyz_length, sph, sph_len);
 }
 
@@ -69,9 +76,10 @@ void cpu_sph_with_gradients(void *out_tuple, const void **in) {
     static CacheMap<T> sph_cache;
     static std::mutex cache_mutex;
 
-    auto& calculator = _get_or_create_sph(sph_cache, cache_mutex, l_max, normalized);
-    calculator->compute_array_with_gradients(xyz, xyz_length, sph, sph_len, dsph,
-                                            dsph_len);
+    auto &calculator =
+        _get_or_create_sph(sph_cache, cache_mutex, l_max, normalized);
+    calculator->compute_array_with_gradients(xyz, xyz_length, sph, sph_len,
+                                             dsph, dsph_len);
 }
 
 template <typename T>
@@ -95,9 +103,10 @@ void cpu_sph_with_hessians(void *out_tuple, const void **in) {
     static CacheMap<T> sph_cache;
     static std::mutex cache_mutex;
 
-    auto& calculator = _get_or_create_sph(sph_cache, cache_mutex, l_max, normalized);
+    auto &calculator =
+        _get_or_create_sph(sph_cache, cache_mutex, l_max, normalized);
     calculator->compute_array_with_hessians(xyz, xyz_length, sph, sph_len, dsph,
-                                           dsph_len, ddsph, ddsph_len);
+                                            dsph_len, ddsph, ddsph_len);
 }
 
 pybind11::dict Registrations() {

--- a/sphericart-jax/src/jax.cpp
+++ b/sphericart-jax/src/jax.cpp
@@ -4,6 +4,9 @@
 // for each supported dtype.
 
 #include <cstdlib>
+#include <map>
+#include <mutex>
+#include <tuple>
 
 #include "sphericart.hpp"
 #include "sphericart/pybind11_kernel_helpers.h"
@@ -11,6 +14,22 @@
 using namespace sphericart_jax;
 
 namespace {
+
+template<typename T> 
+using CacheMap = std::map<std::tuple<size_t, bool>, std::unique_ptr<sphericart::SphericalHarmonics<T>>>;
+
+template <typename T> std::unique_ptr<sphericart::SphericalHarmonics<T>>&
+    _get_or_create_sph(CacheMap<T>& sph_cache , std::mutex& cache_mutex,
+        size_t l_max, bool normalized  ) {
+    // Check if instance exists in cache, if not create and store it    
+    std::lock_guard<std::mutex> lock(cache_mutex);
+    auto key = std::make_tuple(l_max, normalized);
+    auto it = sph_cache.find(key);
+    if (it == sph_cache.end()) {
+        it = sph_cache.insert({key,std::make_unique<sphericart::SphericalHarmonics<T>>(l_max, normalized)}).first;            
+    }
+    return it->second;
+}
 
 template <typename T> void cpu_sph(void *out, const void **in) {
     // Parse the inputs
@@ -23,8 +42,12 @@ template <typename T> void cpu_sph(void *out, const void **in) {
     // The output is stored as a single pointer since there is only one output
     T *sph = reinterpret_cast<T *>(out);
 
-    auto calculator = sphericart::SphericalHarmonics<T>(l_max, normalized);
-    calculator.compute_array(xyz, xyz_length, sph, sph_len);
+    // Static map to cache instances based on parameters
+    static CacheMap<T> sph_cache;
+    static std::mutex cache_mutex;
+
+    auto& calculator = _get_or_create_sph(sph_cache, cache_mutex, l_max, normalized);
+    calculator->compute_array(xyz, xyz_length, sph, sph_len);
 }
 
 template <typename T>
@@ -42,8 +65,12 @@ void cpu_sph_with_gradients(void *out_tuple, const void **in) {
     T *sph = reinterpret_cast<T *>(out[0]);
     T *dsph = reinterpret_cast<T *>(out[1]);
 
-    auto calculator = sphericart::SphericalHarmonics<T>(l_max, normalized);
-    calculator.compute_array_with_gradients(xyz, xyz_length, sph, sph_len, dsph,
+    // Static map to cache instances based on parameters
+    static CacheMap<T> sph_cache;
+    static std::mutex cache_mutex;
+
+    auto& calculator = _get_or_create_sph(sph_cache, cache_mutex, l_max, normalized);
+    calculator->compute_array_with_gradients(xyz, xyz_length, sph, sph_len, dsph,
                                             dsph_len);
 }
 
@@ -64,8 +91,12 @@ void cpu_sph_with_hessians(void *out_tuple, const void **in) {
     T *dsph = reinterpret_cast<T *>(out[1]);
     T *ddsph = reinterpret_cast<T *>(out[2]);
 
-    auto calculator = sphericart::SphericalHarmonics<T>(l_max, normalized);
-    calculator.compute_array_with_hessians(xyz, xyz_length, sph, sph_len, dsph,
+    // Static map to cache instances based on parameters
+    static CacheMap<T> sph_cache;
+    static std::mutex cache_mutex;
+
+    auto& calculator = _get_or_create_sph(sph_cache, cache_mutex, l_max, normalized);
+    calculator->compute_array_with_hessians(xyz, xyz_length, sph, sph_len, dsph,
                                            dsph_len, ddsph, ddsph_len);
 }
 


### PR DESCRIPTION
As the title says - the C++ class gets cached to avoid recomputing prefactors and allocating buffers