### PR TITLE
Add support for non-default CUDA streams.

### DIFF
--- a/sphericart-torch/include/sphericart/cuda.hpp
+++ b/sphericart-torch/include/sphericart/cuda.hpp
@@ -14,10 +14,12 @@ bool adjust_cuda_shared_memory(at::ScalarType scalar_type, int64_t l_max,
 std::vector<at::Tensor>
 spherical_harmonics_cuda(at::Tensor xyz, at::Tensor prefactors, int64_t l_max,
                          bool normalize, int64_t GRID_DIM_X, int64_t GRID_DIM_Y,
-                         bool gradients, bool hessians, cudaStream_t stream=0);
+                         bool gradients, bool hessians,
+                         cudaStream_t stream = 0);
 
 at::Tensor spherical_harmonics_backward_cuda(at::Tensor xyz, at::Tensor dsph,
-                                             at::Tensor sph_grad, cudaStream_t stream=0);
+                                             at::Tensor sph_grad,
+                                             cudaStream_t stream = 0);
 
 at::Tensor prefactors_cuda(int64_t l_max, at::ScalarType dtype);
 

--- a/sphericart-torch/include/sphericart/cuda.hpp
+++ b/sphericart-torch/include/sphericart/cuda.hpp
@@ -2,7 +2,7 @@
 #define SPHERICART_TORCH_CUDA_HPP
 
 #include <ATen/Tensor.h>
-
+#include <cuda_runtime.h>
 #include <vector>
 
 namespace sphericart_torch {
@@ -14,10 +14,10 @@ bool adjust_cuda_shared_memory(at::ScalarType scalar_type, int64_t l_max,
 std::vector<at::Tensor>
 spherical_harmonics_cuda(at::Tensor xyz, at::Tensor prefactors, int64_t l_max,
                          bool normalize, int64_t GRID_DIM_X, int64_t GRID_DIM_Y,
-                         bool gradients, bool hessians);
+                         bool gradients, bool hessians, cudaStream_t stream=0);
 
 at::Tensor spherical_harmonics_backward_cuda(at::Tensor xyz, at::Tensor dsph,
-                                             at::Tensor sph_grad);
+                                             at::Tensor sph_grad, cudaStream_t stream=0);
 
 at::Tensor prefactors_cuda(int64_t l_max, at::ScalarType dtype);
 

--- a/sphericart-torch/src/autograd.cpp
+++ b/sphericart-torch/src/autograd.cpp
@@ -209,7 +209,7 @@ torch::autograd::variable_list SphericalHarmonicsAutograd::forward(
         c10::cuda::CUDAGuard deviceGuard{xyz.device()};
         cudaStream_t stream = c10::cuda::getCurrentCUDAStream();
 
-        // re-do the shared memory update in case `requires_grad` changed        
+        // re-do the shared memory update in case `requires_grad` changed
 
         const std::lock_guard<std::mutex> guard(calculator.cuda_shmem_mutex_);
 
@@ -268,8 +268,7 @@ torch::autograd::variable_list SphericalHarmonicsAutograd::forward(
             do_gradients || xyz.requires_grad(),
             do_hessians || (xyz.requires_grad() &&
                             calculator.backward_second_derivatives_),
-            stream
-        );
+            stream);
 
         sph = results[0];
         dsph = results[1];
@@ -325,8 +324,8 @@ torch::Tensor SphericalHarmonicsAutogradBackward::forward(
             c10::cuda::CUDAGuard deviceGuard{xyz.device()};
             cudaStream_t stream = c10::cuda::getCurrentCUDAStream();
 
-            xyz_grad =
-                spherical_harmonics_backward_cuda(xyz, dsph, grad_outputs, stream);
+            xyz_grad = spherical_harmonics_backward_cuda(xyz, dsph,
+                                                         grad_outputs, stream);
         } else {
             throw std::runtime_error(
                 "Spherical harmonics are only implemented for CPU and CUDA");

--- a/sphericart-torch/src/cuda.cu
+++ b/sphericart-torch/src/cuda.cu
@@ -638,8 +638,8 @@ std::vector<torch::Tensor> sphericart_torch::spherical_harmonics_cuda(
                 xyz.requires_grad() || gradients,
                 xyz.requires_grad() && hessian);
 
-            spherical_harmonics_kernel<<<block_dim, grid_dim,
-                                         total_buff_size, stream>>>(
+            spherical_harmonics_kernel<<<block_dim, grid_dim, total_buff_size,
+                                         stream>>>(
 
                 xyz.packed_accessor64<scalar_t, 2, torch::RestrictPtrTraits>(),
                 prefactors
@@ -705,7 +705,8 @@ __global__ void backward_kernel(
     Wrapper for the CUDA kernel backwards pass.
 */
 torch::Tensor sphericart_torch::spherical_harmonics_backward_cuda(
-    torch::Tensor xyz, torch::Tensor dsph, torch::Tensor sph_grad, cudaStream_t stream) {
+    torch::Tensor xyz, torch::Tensor dsph, torch::Tensor sph_grad,
+    cudaStream_t stream) {
 
     if (!xyz.device().is_cuda()) {
         throw std::runtime_error(


### PR DESCRIPTION
Currently, Sphericart only supports tensors / operations on the default stream. These changes allow it to work with inputs on any CUDA stream.