### PR TITLE
Updated CI to use an image with Python 3.10 installed

### DIFF
--- a/ci/docker/Dockerfile.build
+++ b/ci/docker/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM docker.io/prashanthkanduri/librascal-pytorch2:latest
+FROM docker.io/prashanthkanduri/librascal-pytorch2:python310
 
 COPY . /sphericart
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -26,7 +26,7 @@ test_job:
     - tox
     - mkdir buildcpp
     - cd buildcpp
-    - export Torch_DIR=/usr/local/lib/python3.8/dist-packages/torch/share/cmake/Torch
+    - export Torch_DIR=/usr/local/lib/python3.10/dist-packages/torch/share/cmake/Torch/
     - cmake .. -DSPHERICART_BUILD_TESTS=ON -DSPHERICART_OPENMP=ON -DSPHERICART_BUILD_EXAMPLES=ON -DSPHERICART_BUILD_TORCH=ON
     - cmake --build .
     - ctest


### PR DESCRIPTION
Once this is merged with main, any branch that builds on top of main should be able to trigger the CI with a new image with Python 3.10 in the environment