### PR TITLE
Disentangle hardcoding and templating

### DIFF
--- a/benchmarks/cpp/benchmark.cpp
+++ b/benchmarks/cpp/benchmark.cpp
@@ -23,13 +23,13 @@ inline void compute_generic(int n_samples, int l_max, DTYPE *prefactors,
                             DTYPE *xyz, DTYPE *sph, DTYPE *dsph, DTYPE *ddsph,
                             DTYPE *buffers) {
     if (dsph == nullptr) {
-        generic_sph<DTYPE, false, false, false, 1>(
+        generic_sph<DTYPE, false, false, false, 1, 10>(
             xyz, sph, dsph, ddsph, n_samples, l_max, prefactors, buffers);
     } else if (ddsph == nullptr) {
-        generic_sph<DTYPE, true, false, false, 1>(
+        generic_sph<DTYPE, true, false, false, 1, 10>(
             xyz, sph, dsph, ddsph, n_samples, l_max, prefactors, buffers);
     } else {
-        generic_sph<DTYPE, true, true, false, 1>(
+        generic_sph<DTYPE, true, true, false, 1, 10>(
             xyz, sph, dsph, ddsph, n_samples, l_max, prefactors, buffers);
     }
 }

--- a/python/tests/test_vs_scipy.py
+++ b/python/tests/test_vs_scipy.py
@@ -112,7 +112,7 @@ def test_second_derivatives(xyz):
                     :, alpha, beta, :
                 ]
                 # Lower the tolerances as numerical second derivatives are imprecise:
-                print(numerical_second_derivatives - analytical_second_derivatives)
+                print(np.where(analytical_second_derivatives[0] == 0.0)[0])
                 assert np.allclose(
                     numerical_second_derivatives,
                     analytical_second_derivatives,

--- a/sphericart/include/templates.hpp
+++ b/sphericart/include/templates.hpp
@@ -19,8 +19,8 @@
 #define SPHERICART_LMAX_TEMPLATED 10
 
 #include <cmath>
-#include <vector>
 #include <iostream>
+#include <vector>
 
 #ifdef _OPENMP
 
@@ -639,7 +639,8 @@ CUDA_DEVICE_PREFIX static inline void generic_sph_l_channel(
 }
 
 template <typename T, bool DO_DERIVATIVES, bool DO_SECOND_DERIVATIVES,
-          int HARDCODED_LMAX, int TEMPLATED_L, int (*GET_INDEX)(int) = dummy_idx>
+          int HARDCODED_LMAX, int TEMPLATED_L,
+          int (*GET_INDEX)(int) = dummy_idx>
 CUDA_DEVICE_PREFIX static inline void generic_sph_l_channel_templated(
     [[maybe_unused]] T x, // these might be unused for low LMAX. not worth a
                           // full separate implementation
@@ -653,11 +654,10 @@ CUDA_DEVICE_PREFIX static inline void generic_sph_l_channel_templated(
     [[maybe_unused]] T *dzdy_sph_i, [[maybe_unused]] T *dzdz_sph_i) {
 
     generic_sph_l_channel<T, DO_DERIVATIVES, DO_SECOND_DERIVATIVES,
-                        HARDCODED_LMAX>(
-    TEMPLATED_L, x, y, z, rxy, pk, qlmk, c, s, twomz, sph_i, dx_sph_i, dy_sph_i,
-    dz_sph_i, dxdx_sph_i, dxdy_sph_i, dxdz_sph_i, dydx_sph_i,
-    dydy_sph_i, dydz_sph_i, dzdx_sph_i, dzdy_sph_i, dzdz_sph_i);
-
+                          HARDCODED_LMAX>(
+        TEMPLATED_L, x, y, z, rxy, pk, qlmk, c, s, twomz, sph_i, dx_sph_i,
+        dy_sph_i, dz_sph_i, dxdx_sph_i, dxdy_sph_i, dxdz_sph_i, dydx_sph_i,
+        dydy_sph_i, dydz_sph_i, dzdx_sph_i, dzdy_sph_i, dzdz_sph_i);
 }
 
 template <typename T, bool DO_DERIVATIVES, bool DO_SECOND_DERIVATIVES,
@@ -766,7 +766,8 @@ generic_sph_sample(const T *xyz_i, T *sph_i, [[maybe_unused]] T *dsph_i,
     // also initialize the sine and cosine, even if these never change
     c[0] = 1.0;
     s[0] = 0.0;
-    for (m = 1; m < TEMPLATED_LMAX + 1; ++m) {  // allow unrolling of the static part of the loop
+    for (m = 1; m < TEMPLATED_LMAX + 1;
+         ++m) { // allow unrolling of the static part of the loop
         c[m] = c[m - 1] * x - s[m - 1] * y;
         s[m] = c[m - 1] * y + s[m - 1] * x;
         twomz[m] = twomz[m - 1] + twoz;
@@ -812,82 +813,103 @@ generic_sph_sample(const T *xyz_i, T *sph_i, [[maybe_unused]] T *dsph_i,
     auto pk = pylm + k;
     auto qlmk = pqlm + k; // starts at HARDCODED_LMAX+1
     for (int l = HARDCODED_LMAX + 1; l < l_max + 1; l++) {
-        if (l <= TEMPLATED_LMAX) { 
+        if (l <= TEMPLATED_LMAX) {
             // call templated version
-            // generic_sph_l_channel_templated<T, DO_DERIVATIVES, DO_SECOND_DERIVATIVES,
+            // generic_sph_l_channel_templated<T, DO_DERIVATIVES,
+            // DO_SECOND_DERIVATIVES,
             //                       HARDCODED_LMAX, l>(
-            //     x, y, z, rxy, pk, qlmk, c, s, twomz, sph_i, dx_sph_i, dy_sph_i,
-            //     dz_sph_i, dxdx_sph_i, dxdy_sph_i, dxdz_sph_i, dydx_sph_i,
-            //     dydy_sph_i, dydz_sph_i, dzdx_sph_i, dzdy_sph_i, dzdz_sph_i);
+            //     x, y, z, rxy, pk, qlmk, c, s, twomz, sph_i, dx_sph_i,
+            //     dy_sph_i, dz_sph_i, dxdx_sph_i, dxdy_sph_i, dxdz_sph_i,
+            //     dydx_sph_i, dydy_sph_i, dydz_sph_i, dzdx_sph_i, dzdy_sph_i,
+            //     dzdz_sph_i);
             if (l == 2) {
-                generic_sph_l_channel_templated<T, DO_DERIVATIVES, DO_SECOND_DERIVATIVES,
-                                   HARDCODED_LMAX, 2>(
-                 x, y, z, rxy, pk, qlmk, c, s, twomz, sph_i, dx_sph_i, dy_sph_i,
-                 dz_sph_i, dxdx_sph_i, dxdy_sph_i, dxdz_sph_i, dydx_sph_i,
-                 dydy_sph_i, dydz_sph_i, dzdx_sph_i, dzdy_sph_i, dzdz_sph_i);
+                generic_sph_l_channel_templated<T, DO_DERIVATIVES,
+                                                DO_SECOND_DERIVATIVES,
+                                                HARDCODED_LMAX, 2>(
+                    x, y, z, rxy, pk, qlmk, c, s, twomz, sph_i, dx_sph_i,
+                    dy_sph_i, dz_sph_i, dxdx_sph_i, dxdy_sph_i, dxdz_sph_i,
+                    dydx_sph_i, dydy_sph_i, dydz_sph_i, dzdx_sph_i, dzdy_sph_i,
+                    dzdz_sph_i);
             }
             if (l == 3) {
-                generic_sph_l_channel_templated<T, DO_DERIVATIVES, DO_SECOND_DERIVATIVES,
-                                   HARDCODED_LMAX, 3>(
-                 x, y, z, rxy, pk, qlmk, c, s, twomz, sph_i, dx_sph_i, dy_sph_i,
-                 dz_sph_i, dxdx_sph_i, dxdy_sph_i, dxdz_sph_i, dydx_sph_i,
-                 dydy_sph_i, dydz_sph_i, dzdx_sph_i, dzdy_sph_i, dzdz_sph_i);
+                generic_sph_l_channel_templated<T, DO_DERIVATIVES,
+                                                DO_SECOND_DERIVATIVES,
+                                                HARDCODED_LMAX, 3>(
+                    x, y, z, rxy, pk, qlmk, c, s, twomz, sph_i, dx_sph_i,
+                    dy_sph_i, dz_sph_i, dxdx_sph_i, dxdy_sph_i, dxdz_sph_i,
+                    dydx_sph_i, dydy_sph_i, dydz_sph_i, dzdx_sph_i, dzdy_sph_i,
+                    dzdz_sph_i);
             }
             if (l == 4) {
-                generic_sph_l_channel_templated<T, DO_DERIVATIVES, DO_SECOND_DERIVATIVES,
-                                   HARDCODED_LMAX, 4>(
-                 x, y, z, rxy, pk, qlmk, c, s, twomz, sph_i, dx_sph_i, dy_sph_i,
-                 dz_sph_i, dxdx_sph_i, dxdy_sph_i, dxdz_sph_i, dydx_sph_i,
-                 dydy_sph_i, dydz_sph_i, dzdx_sph_i, dzdy_sph_i, dzdz_sph_i);
+                generic_sph_l_channel_templated<T, DO_DERIVATIVES,
+                                                DO_SECOND_DERIVATIVES,
+                                                HARDCODED_LMAX, 4>(
+                    x, y, z, rxy, pk, qlmk, c, s, twomz, sph_i, dx_sph_i,
+                    dy_sph_i, dz_sph_i, dxdx_sph_i, dxdy_sph_i, dxdz_sph_i,
+                    dydx_sph_i, dydy_sph_i, dydz_sph_i, dzdx_sph_i, dzdy_sph_i,
+                    dzdz_sph_i);
             }
             if (l == 5) {
-                generic_sph_l_channel_templated<T, DO_DERIVATIVES, DO_SECOND_DERIVATIVES,
-                                   HARDCODED_LMAX, 5>(
-                 x, y, z, rxy, pk, qlmk, c, s, twomz, sph_i, dx_sph_i, dy_sph_i,
-                 dz_sph_i, dxdx_sph_i, dxdy_sph_i, dxdz_sph_i, dydx_sph_i,
-                 dydy_sph_i, dydz_sph_i, dzdx_sph_i, dzdy_sph_i, dzdz_sph_i);
+                generic_sph_l_channel_templated<T, DO_DERIVATIVES,
+                                                DO_SECOND_DERIVATIVES,
+                                                HARDCODED_LMAX, 5>(
+                    x, y, z, rxy, pk, qlmk, c, s, twomz, sph_i, dx_sph_i,
+                    dy_sph_i, dz_sph_i, dxdx_sph_i, dxdy_sph_i, dxdz_sph_i,
+                    dydx_sph_i, dydy_sph_i, dydz_sph_i, dzdx_sph_i, dzdy_sph_i,
+                    dzdz_sph_i);
             }
             if (l == 6) {
-                generic_sph_l_channel_templated<T, DO_DERIVATIVES, DO_SECOND_DERIVATIVES,
-                                   HARDCODED_LMAX, 6>(
-                 x, y, z, rxy, pk, qlmk, c, s, twomz, sph_i, dx_sph_i, dy_sph_i,
-                 dz_sph_i, dxdx_sph_i, dxdy_sph_i, dxdz_sph_i, dydx_sph_i,
-                 dydy_sph_i, dydz_sph_i, dzdx_sph_i, dzdy_sph_i, dzdz_sph_i);
+                generic_sph_l_channel_templated<T, DO_DERIVATIVES,
+                                                DO_SECOND_DERIVATIVES,
+                                                HARDCODED_LMAX, 6>(
+                    x, y, z, rxy, pk, qlmk, c, s, twomz, sph_i, dx_sph_i,
+                    dy_sph_i, dz_sph_i, dxdx_sph_i, dxdy_sph_i, dxdz_sph_i,
+                    dydx_sph_i, dydy_sph_i, dydz_sph_i, dzdx_sph_i, dzdy_sph_i,
+                    dzdz_sph_i);
             }
             if (l == 7) {
-                generic_sph_l_channel_templated<T, DO_DERIVATIVES, DO_SECOND_DERIVATIVES,
-                                   HARDCODED_LMAX, 7>(
-                 x, y, z, rxy, pk, qlmk, c, s, twomz, sph_i, dx_sph_i, dy_sph_i,
-                 dz_sph_i, dxdx_sph_i, dxdy_sph_i, dxdz_sph_i, dydx_sph_i,
-                 dydy_sph_i, dydz_sph_i, dzdx_sph_i, dzdy_sph_i, dzdz_sph_i);
+                generic_sph_l_channel_templated<T, DO_DERIVATIVES,
+                                                DO_SECOND_DERIVATIVES,
+                                                HARDCODED_LMAX, 7>(
+                    x, y, z, rxy, pk, qlmk, c, s, twomz, sph_i, dx_sph_i,
+                    dy_sph_i, dz_sph_i, dxdx_sph_i, dxdy_sph_i, dxdz_sph_i,
+                    dydx_sph_i, dydy_sph_i, dydz_sph_i, dzdx_sph_i, dzdy_sph_i,
+                    dzdz_sph_i);
             }
             if (l == 8) {
-                generic_sph_l_channel_templated<T, DO_DERIVATIVES, DO_SECOND_DERIVATIVES,
-                                   HARDCODED_LMAX, 8>(
-                 x, y, z, rxy, pk, qlmk, c, s, twomz, sph_i, dx_sph_i, dy_sph_i,
-                 dz_sph_i, dxdx_sph_i, dxdy_sph_i, dxdz_sph_i, dydx_sph_i,
-                 dydy_sph_i, dydz_sph_i, dzdx_sph_i, dzdy_sph_i, dzdz_sph_i);
+                generic_sph_l_channel_templated<T, DO_DERIVATIVES,
+                                                DO_SECOND_DERIVATIVES,
+                                                HARDCODED_LMAX, 8>(
+                    x, y, z, rxy, pk, qlmk, c, s, twomz, sph_i, dx_sph_i,
+                    dy_sph_i, dz_sph_i, dxdx_sph_i, dxdy_sph_i, dxdz_sph_i,
+                    dydx_sph_i, dydy_sph_i, dydz_sph_i, dzdx_sph_i, dzdy_sph_i,
+                    dzdz_sph_i);
             }
             if (l == 9) {
-                generic_sph_l_channel_templated<T, DO_DERIVATIVES, DO_SECOND_DERIVATIVES,
-                                   HARDCODED_LMAX, 9>(
-                 x, y, z, rxy, pk, qlmk, c, s, twomz, sph_i, dx_sph_i, dy_sph_i,
-                 dz_sph_i, dxdx_sph_i, dxdy_sph_i, dxdz_sph_i, dydx_sph_i,
-                 dydy_sph_i, dydz_sph_i, dzdx_sph_i, dzdy_sph_i, dzdz_sph_i);
+                generic_sph_l_channel_templated<T, DO_DERIVATIVES,
+                                                DO_SECOND_DERIVATIVES,
+                                                HARDCODED_LMAX, 9>(
+                    x, y, z, rxy, pk, qlmk, c, s, twomz, sph_i, dx_sph_i,
+                    dy_sph_i, dz_sph_i, dxdx_sph_i, dxdy_sph_i, dxdz_sph_i,
+                    dydx_sph_i, dydy_sph_i, dydz_sph_i, dzdx_sph_i, dzdy_sph_i,
+                    dzdz_sph_i);
             }
             if (l == 10) {
-                generic_sph_l_channel_templated<T, DO_DERIVATIVES, DO_SECOND_DERIVATIVES,
-                                   HARDCODED_LMAX, 10>(
-                 x, y, z, rxy, pk, qlmk, c, s, twomz, sph_i, dx_sph_i, dy_sph_i,
-                 dz_sph_i, dxdx_sph_i, dxdy_sph_i, dxdz_sph_i, dydx_sph_i,
-                 dydy_sph_i, dydz_sph_i, dzdx_sph_i, dzdy_sph_i, dzdz_sph_i);
+                generic_sph_l_channel_templated<T, DO_DERIVATIVES,
+                                                DO_SECOND_DERIVATIVES,
+                                                HARDCODED_LMAX, 10>(
+                    x, y, z, rxy, pk, qlmk, c, s, twomz, sph_i, dx_sph_i,
+                    dy_sph_i, dz_sph_i, dxdx_sph_i, dxdy_sph_i, dxdz_sph_i,
+                    dydx_sph_i, dydy_sph_i, dydz_sph_i, dzdx_sph_i, dzdy_sph_i,
+                    dzdz_sph_i);
             }
         } else {
-        generic_sph_l_channel<T, DO_DERIVATIVES, DO_SECOND_DERIVATIVES,
-                              HARDCODED_LMAX>(
-            l, x, y, z, rxy, pk, qlmk, c, s, twomz, sph_i, dx_sph_i, dy_sph_i,
-            dz_sph_i, dxdx_sph_i, dxdy_sph_i, dxdz_sph_i, dydx_sph_i,
-            dydy_sph_i, dydz_sph_i, dzdx_sph_i, dzdy_sph_i, dzdz_sph_i);
+            generic_sph_l_channel<T, DO_DERIVATIVES, DO_SECOND_DERIVATIVES,
+                                  HARDCODED_LMAX>(
+                l, x, y, z, rxy, pk, qlmk, c, s, twomz, sph_i, dx_sph_i,
+                dy_sph_i, dz_sph_i, dxdx_sph_i, dxdy_sph_i, dxdz_sph_i,
+                dydx_sph_i, dydy_sph_i, dydz_sph_i, dzdx_sph_i, dzdy_sph_i,
+                dzdz_sph_i);
         }
 
         // shift pointers & indexes to the next l block

--- a/sphericart/include/templates.hpp
+++ b/sphericart/include/templates.hpp
@@ -336,7 +336,7 @@ int inline dummy_idx(int i) { return i; }
  */
 template <typename T, bool DO_DERIVATIVES, bool DO_SECOND_DERIVATIVES,
           int HARDCODED_LMAX, int (*GET_INDEX)(int) = dummy_idx>
-CUDA_DEVICE_PREFIX static inline void generic_sph_l_channel(
+CUDA_DEVICE_PREFIX static __attribute__((always_inline)) void generic_sph_l_channel(
     int l,
     [[maybe_unused]] T x, // these might be unused for low LMAX. not worth a
                           // full separate implementation

--- a/sphericart/include/templates.hpp
+++ b/sphericart/include/templates.hpp
@@ -766,7 +766,7 @@ generic_sph_sample(const T *xyz_i, T *sph_i, [[maybe_unused]] T *dsph_i,
     // also initialize the sine and cosine, even if these never change
     c[0] = 1.0;
     s[0] = 0.0;
-    for (m = 1; m < TEMPLATED_LMAX + 1;
+    for (m = 1; m < HARDCODED_LMAX + 1;  // can we change this to TEMPLATED_LMAX somehow?
          ++m) { // allow unrolling of the static part of the loop
         c[m] = c[m - 1] * x - s[m - 1] * y;
         s[m] = c[m - 1] * y + s[m - 1] * x;

--- a/sphericart/include/templates.hpp
+++ b/sphericart/include/templates.hpp
@@ -766,8 +766,9 @@ generic_sph_sample(const T *xyz_i, T *sph_i, [[maybe_unused]] T *dsph_i,
     // also initialize the sine and cosine, even if these never change
     c[0] = 1.0;
     s[0] = 0.0;
-    for (m = 1; m < HARDCODED_LMAX + 1;  // can we change this to TEMPLATED_LMAX somehow?
-         ++m) { // allow unrolling of the static part of the loop
+    for (m = 1; m < HARDCODED_LMAX +
+                        1; // can we change this to TEMPLATED_LMAX somehow?
+         ++m) {            // allow unrolling of the static part of the loop
         c[m] = c[m - 1] * x - s[m - 1] * y;
         s[m] = c[m - 1] * y + s[m - 1] * x;
         twomz[m] = twomz[m - 1] + twoz;

--- a/sphericart/src/sphericart.cpp
+++ b/sphericart/src/sphericart.cpp
@@ -81,26 +81,26 @@ SphericalHarmonics<T>::SphericalHarmonics(size_t l_max, bool normalized) {
     } else {
         if (this->normalized) {
             this->_array_no_derivatives =
-                &generic_sph<T, false, false, true, SPHERICART_LMAX_HARDCODED>;
+                &generic_sph<T, false, false, true, SPHERICART_LMAX_HARDCODED, SPHERICART_LMAX_TEMPLATED>;
             this->_array_with_derivatives =
-                &generic_sph<T, true, false, true, SPHERICART_LMAX_HARDCODED>;
+                &generic_sph<T, true, false, true, SPHERICART_LMAX_HARDCODED, SPHERICART_LMAX_TEMPLATED>;
             this->_sample_no_derivatives =
                 &generic_sph_sample<T, false, false, true,
-                                    SPHERICART_LMAX_HARDCODED>;
+                                    SPHERICART_LMAX_HARDCODED, SPHERICART_LMAX_TEMPLATED>;
             this->_sample_with_derivatives =
                 &generic_sph_sample<T, true, false, true,
-                                    SPHERICART_LMAX_HARDCODED>;
+                                    SPHERICART_LMAX_HARDCODED, SPHERICART_LMAX_TEMPLATED>;
         } else {
             this->_array_no_derivatives =
-                &generic_sph<T, false, false, false, SPHERICART_LMAX_HARDCODED>;
+                &generic_sph<T, false, false, false, SPHERICART_LMAX_HARDCODED, SPHERICART_LMAX_TEMPLATED>;
             this->_array_with_derivatives =
-                &generic_sph<T, true, false, false, SPHERICART_LMAX_HARDCODED>;
+                &generic_sph<T, true, false, false, SPHERICART_LMAX_HARDCODED, SPHERICART_LMAX_TEMPLATED>;
             this->_sample_no_derivatives =
                 &generic_sph_sample<T, false, false, false,
-                                    SPHERICART_LMAX_HARDCODED>;
+                                    SPHERICART_LMAX_HARDCODED, SPHERICART_LMAX_TEMPLATED>;
             this->_sample_with_derivatives =
                 &generic_sph_sample<T, true, false, false,
-                                    SPHERICART_LMAX_HARDCODED>;
+                                    SPHERICART_LMAX_HARDCODED, SPHERICART_LMAX_TEMPLATED>;
         }
     }
 
@@ -117,9 +117,9 @@ SphericalHarmonics<T>::SphericalHarmonics(size_t l_max, bool normalized) {
         } else { // second derivatives are not hardcoded past l = 1. Call
                  // generic
             // implementations
-            this->_array_with_hessians = &generic_sph<T, true, true, true, 1>;
+            this->_array_with_hessians = &generic_sph<T, true, true, true, 1, SPHERICART_LMAX_TEMPLATED>;
             this->_sample_with_hessians =
-                &generic_sph_sample<T, true, true, true, 1>;
+                &generic_sph_sample<T, true, true, true, 1, SPHERICART_LMAX_TEMPLATED>;
         }
     } else {
         if (this->l_max == 0) {
@@ -135,9 +135,9 @@ SphericalHarmonics<T>::SphericalHarmonics(size_t l_max, bool normalized) {
         } else { // second derivatives are not hardcoded past l = 1. Call
                  // generic
             // implementations
-            this->_array_with_hessians = &generic_sph<T, true, true, false, 1>;
+            this->_array_with_hessians = &generic_sph<T, true, true, false, 1, SPHERICART_LMAX_TEMPLATED>;
             this->_sample_with_hessians =
-                &generic_sph_sample<T, true, true, false, 1>;
+                &generic_sph_sample<T, true, true, false, 1, SPHERICART_LMAX_TEMPLATED>;
         }
     }
 }

--- a/sphericart/src/sphericart.cpp
+++ b/sphericart/src/sphericart.cpp
@@ -81,26 +81,34 @@ SphericalHarmonics<T>::SphericalHarmonics(size_t l_max, bool normalized) {
     } else {
         if (this->normalized) {
             this->_array_no_derivatives =
-                &generic_sph<T, false, false, true, SPHERICART_LMAX_HARDCODED, SPHERICART_LMAX_TEMPLATED>;
+                &generic_sph<T, false, false, true, SPHERICART_LMAX_HARDCODED,
+                             SPHERICART_LMAX_TEMPLATED>;
             this->_array_with_derivatives =
-                &generic_sph<T, true, false, true, SPHERICART_LMAX_HARDCODED, SPHERICART_LMAX_TEMPLATED>;
+                &generic_sph<T, true, false, true, SPHERICART_LMAX_HARDCODED,
+                             SPHERICART_LMAX_TEMPLATED>;
             this->_sample_no_derivatives =
                 &generic_sph_sample<T, false, false, true,
-                                    SPHERICART_LMAX_HARDCODED, SPHERICART_LMAX_TEMPLATED>;
+                                    SPHERICART_LMAX_HARDCODED,
+                                    SPHERICART_LMAX_TEMPLATED>;
             this->_sample_with_derivatives =
                 &generic_sph_sample<T, true, false, true,
-                                    SPHERICART_LMAX_HARDCODED, SPHERICART_LMAX_TEMPLATED>;
+                                    SPHERICART_LMAX_HARDCODED,
+                                    SPHERICART_LMAX_TEMPLATED>;
         } else {
             this->_array_no_derivatives =
-                &generic_sph<T, false, false, false, SPHERICART_LMAX_HARDCODED, SPHERICART_LMAX_TEMPLATED>;
+                &generic_sph<T, false, false, false, SPHERICART_LMAX_HARDCODED,
+                             SPHERICART_LMAX_TEMPLATED>;
             this->_array_with_derivatives =
-                &generic_sph<T, true, false, false, SPHERICART_LMAX_HARDCODED, SPHERICART_LMAX_TEMPLATED>;
+                &generic_sph<T, true, false, false, SPHERICART_LMAX_HARDCODED,
+                             SPHERICART_LMAX_TEMPLATED>;
             this->_sample_no_derivatives =
                 &generic_sph_sample<T, false, false, false,
-                                    SPHERICART_LMAX_HARDCODED, SPHERICART_LMAX_TEMPLATED>;
+                                    SPHERICART_LMAX_HARDCODED,
+                                    SPHERICART_LMAX_TEMPLATED>;
             this->_sample_with_derivatives =
                 &generic_sph_sample<T, true, false, false,
-                                    SPHERICART_LMAX_HARDCODED, SPHERICART_LMAX_TEMPLATED>;
+                                    SPHERICART_LMAX_HARDCODED,
+                                    SPHERICART_LMAX_TEMPLATED>;
         }
     }
 
@@ -117,9 +125,11 @@ SphericalHarmonics<T>::SphericalHarmonics(size_t l_max, bool normalized) {
         } else { // second derivatives are not hardcoded past l = 1. Call
                  // generic
             // implementations
-            this->_array_with_hessians = &generic_sph<T, true, true, true, 1, SPHERICART_LMAX_TEMPLATED>;
+            this->_array_with_hessians =
+                &generic_sph<T, true, true, true, 1, SPHERICART_LMAX_TEMPLATED>;
             this->_sample_with_hessians =
-                &generic_sph_sample<T, true, true, true, 1, SPHERICART_LMAX_TEMPLATED>;
+                &generic_sph_sample<T, true, true, true, 1,
+                                    SPHERICART_LMAX_TEMPLATED>;
         }
     } else {
         if (this->l_max == 0) {
@@ -135,9 +145,12 @@ SphericalHarmonics<T>::SphericalHarmonics(size_t l_max, bool normalized) {
         } else { // second derivatives are not hardcoded past l = 1. Call
                  // generic
             // implementations
-            this->_array_with_hessians = &generic_sph<T, true, true, false, 1, SPHERICART_LMAX_TEMPLATED>;
+            this->_array_with_hessians =
+                &generic_sph<T, true, true, false, 1,
+                             SPHERICART_LMAX_TEMPLATED>;
             this->_sample_with_hessians =
-                &generic_sph_sample<T, true, true, false, 1, SPHERICART_LMAX_TEMPLATED>;
+                &generic_sph_sample<T, true, true, false, 1,
+                                    SPHERICART_LMAX_TEMPLATED>;
         }
     }
 }

--- a/sphericart/tests/test_hardcoding.cpp
+++ b/sphericart/tests/test_hardcoding.cpp
@@ -21,10 +21,10 @@ inline void compute_generic(int n_samples, int l_max, DTYPE *prefactors,
                             DTYPE *xyz, DTYPE *sph, DTYPE *dsph,
                             DTYPE *buffers) {
     if (dsph == nullptr) {
-        generic_sph<DTYPE, false, false, false, 1>(
+        generic_sph<DTYPE, false, false, false, 1, 10>(
             xyz, sph, dsph, nullptr, n_samples, l_max, prefactors, buffers);
     } else {
-        generic_sph<DTYPE, true, false, false, 1>(
+        generic_sph<DTYPE, true, false, false, 1, 10>(
             xyz, sph, dsph, nullptr, n_samples, l_max, prefactors, buffers);
     }
 }


### PR DESCRIPTION
Following the discussion in #79, I realized that the templating of `l_max` (which leads to loop unrolling) and hardcoding can have different `l_max` thresholds. This would let us reap the benefits of loop unrolling also for `l_max>6`, although I haven't done any speed tests for the moment. An additional benefit is that this would remove the ugly duplication of code in `templates.hpp`, where we can now have a single loop which is fully static. (Here I'm assuming that our new `SPERICART_LMAX_TEMPLATED` would be so high that at that point loop unrolling wouldn't be possible anymore, so that we wouldn't realistically need to try enforcing unrolling for the first part of super-high `l`s and the compiler will choose for us at what point it stops unrolling.)
The only issue is template instantiation. I'm doing it with if statements at the moment (and `SPERICART_LMAX_TEMPLATED=10`) to avoid having to instantiate all the other template parameters, which would be a nightmare. Let me know what you think @ceriottm @Luthaf.