### PR TITLE
Make "release" the default install configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,8 @@ enable_testing()
 # Set a default build type if none was specified
 if (${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_SOURCE_DIR})
     if("${CMAKE_BUILD_TYPE}" STREQUAL "" AND "${CMAKE_CONFIGURATION_TYPES}" STREQUAL "")
-        message(STATUS "Setting build type to 'relwithdebinfo' as none was specified.")
-        set(CMAKE_BUILD_TYPE "relwithdebinfo"
+        message(STATUS "Setting build type to 'release' as none was specified.")
+        set(CMAKE_BUILD_TYPE "release"
             CACHE STRING
             "Choose the type of build, options are: none(CMAKE_CXX_FLAGS or CMAKE_C_FLAGS used) debug release relwithdebinfo minsizerel."
         FORCE)


### PR DESCRIPTION
This uses -O3 instead of -O2. In some cases, -O2 does not allow vectorization