### PR TITLE
Fix Julia code thread safety

### DIFF
--- a/julia/Project.toml
+++ b/julia/Project.toml
@@ -1,7 +1,7 @@
 name = "SpheriCart"
 uuid = "5caf2b29-02d9-47a3-9434-5931c85ba645"
 authors = ["Christoph Ortner <christohortner@gmail.com> and contributors"]
-version = "0.0.2-dev"
+version = "0.0.2"
 
 [deps]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"

--- a/julia/Project.toml
+++ b/julia/Project.toml
@@ -1,7 +1,7 @@
 name = "SpheriCart"
 uuid = "5caf2b29-02d9-47a3-9434-5931c85ba645"
 authors = ["Christoph Ortner <christohortner@gmail.com> and contributors"]
-version = "0.0.2"
+version = "0.0.3"
 
 [deps]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"

--- a/julia/benchmarks/benchmark.jl
+++ b/julia/benchmarks/benchmark.jl
@@ -69,6 +69,7 @@ end
 @info("compute! vs compute_with_gradients! (using 32 inputs)")
 
 for L = 1:2:15
+   local Rs
    @show L 
    nX = 32
    basis = SolidHarmonics(L)
@@ -84,6 +85,7 @@ end
 
 @info("compute vs compute_with_gradients for code-generated basis")
 for L = 1:10
+   local 𝐫
    @show L 
    basis = SolidHarmonics(L; static=true)
    𝐫 = @SVector randn(3)

--- a/julia/src/api.jl
+++ b/julia/src/api.jl
@@ -36,7 +36,7 @@ See documentation for more details.
 """
 struct SolidHarmonics{L, NORM, STATIC, T1}
    Flm::OffsetMatrix{T1, Matrix{T1}}
-   cache::ArrayPool{FlexArrayCache}
+   cache::TSafe{ArrayPool{FlexArrayCache}}
 end
 
 function SolidHarmonics(L::Integer; 
@@ -45,7 +45,7 @@ function SolidHarmonics(L::Integer;
                         T = Float64) 
    Flm = generate_Flms(L; normalisation = normalisation, T = T)
    @assert eltype(Flm) == T   
-   SolidHarmonics{L, normalisation, static, T}(Flm, ArrayPool(FlexArrayCache))
+   SolidHarmonics{L, normalisation, static, T}(Flm, TSafe(ArrayPool(FlexArrayCache)))
 end
 
 @inline (basis::SolidHarmonics)(args...) = compute(basis, args...)

--- a/julia/src/spherical.jl
+++ b/julia/src/spherical.jl
@@ -42,12 +42,12 @@ See documentation for more details.
 struct SphericalHarmonics{L, NORM, STATIC, T1}
    solids::SolidHarmonics{L, NORM, STATIC, T1}
    # Flm::OffsetMatrix{T1, Matrix{T1}}
-   cache::ArrayPool{FlexArrayCache}
+   cache::TSafe{ArrayPool{FlexArrayCache}}
 end
 
 SphericalHarmonics(L::Integer; kwargs...) = 
       SphericalHarmonics(SolidHarmonics(L; kwargs...), 
-                         ArrayPool(FlexArrayCache))
+                         TSafe(ArrayPool(FlexArrayCache)))
 
 
 @inline (basis::SphericalHarmonics)(args...) = compute(basis, args...)

--- a/julia/src/spherical.jl
+++ b/julia/src/spherical.jl
@@ -46,7 +46,7 @@ struct SphericalHarmonics{L, NORM, STATIC, T1}
 end
 
 SphericalHarmonics(L::Integer; kwargs...) = 
-      SphericalHarmonics(SolidHarmonics(L, kwargs...), 
+      SphericalHarmonics(SolidHarmonics(L; kwargs...), 
                          ArrayPool(FlexArrayCache))
 
 


### PR DESCRIPTION
(Second attempt)

When the harmonics were evaluated in a multi-threaded code this led to different threads writing to the same temporary arrays. This PR fixes that. It simply requires replacing the object pool with a thread-safe version.