### PR TITLE
Build wheels using the abi3 tag for sphericart-jax and sphericart-torch

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -30,7 +30,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel build
+        run: python -m pip install cibuildwheel build abi3audit
 
       - name: Build sphericart wheels
         run: |
@@ -81,6 +81,11 @@ jobs:
           CIBW_SKIP: "*-musllinux* *-win32 *-manylinux_i686"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_ENVIRONMENT: SPHERICART_ARCH_NATIVE=OFF
+
+      - name: Check sphericart-torch and sphericart-jax wheels for abi3 compliance
+        run: |
+          abi3audit --verbose sphericart-torch/dist/*.whl
+          abi3audit --verbose sphericart-jax/dist/*.whl
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel build
@@ -39,8 +39,8 @@ jobs:
           python -m cibuildwheel dist/*.tar.gz --output-dir dist
         env:
           CIBW_BUILD_VERBOSITY: 3
-          # build wheels on CPython 3.10
-          CIBW_BUILD: cp310-*
+          # build wheels on CPython 3.12
+          CIBW_BUILD: cp312-*
           # skip musl and 32-bit builds
           CIBW_SKIP: "*-musllinux* *-win32 *-manylinux_i686"
           # on macOS, build both Intel & Apple Silicon versions
@@ -107,7 +107,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: build sdist
         run: |
           python -m pip install build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
       - name: setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: install dependencies
         run: |
           python -m pip install tox

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
       - name: setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: setup Julia
         uses: julia-actions/setup-julia@v1
@@ -63,7 +63,7 @@ jobs:
     name: check Python build
     strategy:
       matrix:
-        python-version: ['3.7', '3.11']
+        python-version: ['3.8', '3.12']
     steps:
       - uses: actions/checkout@v3
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,7 +11,7 @@ build:
   apt_packages:
     - cmake
   tools:
-    python: "3.10"
+    python: "3.12"
   jobs:
     # install sphericart-torch with the CPU version of PyTorch
     # we can not use the `python` section below since it does not allow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "sphericart"
 dynamic = ["version", "optional-dependencies"]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = ["numpy"]
 
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ repository = "https://github.com/lab-cosmo/sphericart"
 requires = [
     "setuptools >=44",
     "wheel >=0.36",
-    "cmake",
+    "cmake ==3.28.4",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/sphericart-jax/include/sphericart/pybind11_kernel_helpers.hpp
+++ b/sphericart-jax/include/sphericart/pybind11_kernel_helpers.hpp
@@ -8,6 +8,10 @@
 #include <string>
 #include <type_traits>
 
+// Use Python limited API corresponding to Python 3.9
+// See https://docs.python.org/3/c-api/stable.html
+#define Py_LIMITED_API 0x0309000000
+
 #include <pybind11/pybind11.h>
 
 namespace sphericart_jax {

--- a/sphericart-jax/pyproject.toml
+++ b/sphericart-jax/pyproject.toml
@@ -55,3 +55,7 @@ zip-safe = false
 where = ["python"]
 include = ["sphericart*"]
 namespaces = true
+
+[tool.distutils.bdist_wheel]
+# Build wheels that are compatible with any Python version after 3.9
+py-limited-api = "cp39"

--- a/sphericart-jax/pyproject.toml
+++ b/sphericart-jax/pyproject.toml
@@ -42,7 +42,7 @@ repository = "https://github.com/lab-cosmo/sphericart"
 requires = [
     "setuptools >=44",
     "wheel >=0.36",
-    "cmake",
+    "cmake ==3.28.4",
     "pybind11>=2.8.0",
 ]
 build-backend = "setuptools.build_meta"

--- a/sphericart-torch/pyproject.toml
+++ b/sphericart-torch/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "sphericart-torch"
 dynamic = ["version"]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = ["torch >= 1.13"]
 
 readme = "README.md"

--- a/sphericart-torch/pyproject.toml
+++ b/sphericart-torch/pyproject.toml
@@ -54,3 +54,7 @@ zip-safe = false
 where = ["python"]
 include = ["sphericart*"]
 namespaces = true
+
+[tool.distutils.bdist_wheel]
+# Build wheels that are compatible with any Python version after 3.8
+py-limited-api = "cp38"

--- a/sphericart-torch/pyproject.toml
+++ b/sphericart-torch/pyproject.toml
@@ -41,7 +41,7 @@ repository = "https://github.com/lab-cosmo/sphericart"
 requires = [
     "setuptools >=44",
     "wheel >=0.36",
-    "cmake",
+    "cmake ==3.28.4",
     "torch >= 1.13",
 ]
 build-backend = "setuptools.build_meta"

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ allowlist_externals =
 
 deps =
     wheel
-    cmake
+    cmake ==3.28.4
 
     numpy
     scipy
@@ -59,7 +59,7 @@ commands =
 # this environement runs tests for the torch bindings
 deps =
     wheel
-    cmake
+    cmake ==3.28.4
 
     numpy
     torch
@@ -79,7 +79,7 @@ commands =
 # this environement runs tests for the jax bindings
 deps =
     wheel
-    cmake
+    cmake ==3.28.4
     sphericart
     pybind11
     numpy
@@ -104,7 +104,7 @@ commands =
 # this environement runs the examples for Python and Pytorch bindings
 deps =
     wheel
-    cmake
+    cmake ==3.28.4
 
     numpy
     torch
@@ -159,7 +159,7 @@ commands =
 deps =
     setuptools
     wheel
-    cmake
+    cmake ==3.28.4
     twine
 
 allowlist_externals =
@@ -181,7 +181,7 @@ commands =
 deps =
     setuptools
     wheel
-    cmake
+    cmake ==3.28.4
     twine
     torch
 
@@ -205,7 +205,7 @@ commands =
 deps =
     setuptools
     wheel
-    cmake
+    cmake ==3.28.4
     twine
     pybind11
 


### PR DESCRIPTION
Python offers a stable ABI since version 3.2, which can be used to build wheels targetting some minimal Python version, and use it with all future Python versions, instead of building one wheel per Python version.

This should be the right thing to do for sphericart-jax where we are linking to Python.h ourself. I'll check that the wheel work and that we don't need to pass other flags to the compiler.

I'm not sure about sphericart-torch: since we are not actually linking to Python.h, we should be able to build a wheel compatible with any Python version (but a single PyTorch version).