### PR TITLE
Parallelize compilation with cmake

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
           mkdir build
           cd build
           cmake -DSPHERICART_BUILD_EXAMPLES=ON -DSPHERICART_BUILD_TESTS=ON ..
-          cmake --build .
+          cmake --build . --parallel
           ctest
 
       - name: run Python tests

--- a/ci/docker/Dockerfile.base
+++ b/ci/docker/Dockerfile.base
@@ -28,7 +28,7 @@ RUN apt-get install -y cargo
 # install rascaline
 RUN pip install git+https://github.com/Luthaf/rascaline/
 
-# install and setup metatensor (formerly equistore)
+# install and set up metatensor
 WORKDIR /workspace/
 RUN git clone https://github.com/lab-cosmo/metatensor \
 	&& cd metatensor \
@@ -36,5 +36,5 @@ RUN git clone https://github.com/lab-cosmo/metatensor \
 	&& cd metatensor-core \
 	&& mkdir build && cd build \
 	&& cmake .. \
-	&& cmake --build . --target install
+	&& cmake --build . --parallel --target install
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -27,7 +27,7 @@ test_job:
     - cd buildcpp
     - export Torch_DIR=/usr/local/lib/python3.10/dist-packages/torch/share/cmake/Torch/
     - cmake .. -DSPHERICART_BUILD_TESTS=ON -DSPHERICART_OPENMP=ON -DSPHERICART_BUILD_EXAMPLES=ON -DSPHERICART_ENABLE_CUDA=ON -DSPHERICART_BUILD_TORCH=ON
-    - cmake --build .
+    - cmake --build . --parallel
     - ctest
 
   variables:

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ class cmake_ext(build_ext):
             check=True,
         )
         subprocess.run(
-            ["cmake", "--build", build_dir, "--target", "install"],
+            ["cmake", "--build", build_dir, "--parallel", "--target", "install"],
             check=True,
         )
 

--- a/sphericart-jax/setup.py
+++ b/sphericart-jax/setup.py
@@ -53,7 +53,7 @@ class cmake_ext(build_ext):
             check=True,
         )
         subprocess.run(
-            ["cmake", "--build", build_dir, "--target", "install"],
+            ["cmake", "--build", build_dir, "--parallel", "--target", "install"],
             check=True,
         )
 

--- a/sphericart-torch/setup.py
+++ b/sphericart-torch/setup.py
@@ -49,7 +49,7 @@ class cmake_ext(build_ext):
             check=True,
         )
         subprocess.run(
-            ["cmake", "--build", build_dir, "--target", "install"],
+            ["cmake", "--build", build_dir, "--parallel", "--target", "install"],
             check=True,
         )
 


### PR DESCRIPTION
We use cmake's `--parallel` flag to speed up compilation for Python builds