### PR TITLE
Raise timeout limits

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -17,7 +17,7 @@ test_job:
   stage: test
   extends: .container-runner-daint-gpu
   image: $BASE_IMAGE
-  timeout: 1h
+  timeout: 2h
   script:
     - export CUDA_HOME="/usr/local/cuda"
     - python3 -m pip install --upgrade pip
@@ -34,5 +34,5 @@ test_job:
     SLURM_JOB_NUM_NODES: 1
     SLURM_PARTITION: normal
     SLURM_NTASKS: 1
-    SLURM_TIMELIMIT: '00:30:00'
+    SLURM_TIMELIMIT: '00:40:00'
     GIT_STRATEGY: fetch

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -8,6 +8,7 @@ stages:
 build_base_image_job:
   stage: build
   extends: .container-builder-dynamic-name
+  timeout: 2h
   variables:
     DOCKERFILE: ci/docker/Dockerfile.base
     WATCH_FILECHANGES: $DOCKERFILE
@@ -17,6 +18,7 @@ test_job:
   stage: test
   extends: .container-runner-daint-gpu
   image: $BASE_IMAGE
+  timeout: 2h
   script:
     - export CUDA_HOME="/usr/local/cuda"
     - python3 -m pip install --upgrade pip

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -17,7 +17,6 @@ test_job:
   stage: test
   extends: .container-runner-daint-gpu
   image: $BASE_IMAGE
-  timeout: 2h
   script:
     - export CUDA_HOME="/usr/local/cuda"
     - python3 -m pip install --upgrade pip


### PR DESCRIPTION
There appears to be issues with the filesystem that is making the pipeline build the environment again rather than load from cache. Raising the timeout limits to ensure that this doesn't cause the CI pipelines to fail due to timeouts.