### PR TITLE
Multiple Devices Support

### DIFF
--- a/sphericart/include/sphericart_cuda.hpp
+++ b/sphericart/include/sphericart_cuda.hpp
@@ -95,9 +95,10 @@ template <typename T> class SphericalHarmonics {
   private:
     size_t l_max; // maximum l value computed by this class
     size_t nprefactors;
-    bool normalized;    // should we normalize the input vectors?
-    T* prefactors_cpu;  // host prefactors buffer
-    T* prefactors_cuda; // storage space for prefactors
+    bool normalized;     // should we normalize the input vectors?
+    T* prefactors_cpu;   // host prefactors buffer
+    T** prefactors_cuda; // storage space for prefactors
+    int device_count;    // number of visible GPU devices
 
     int64_t CUDA_GRID_DIM_X_ = 8;
     int64_t CUDA_GRID_DIM_Y_ = 8;

--- a/sphericart/src/cuda_base.cu
+++ b/sphericart/src/cuda_base.cu
@@ -700,11 +700,16 @@ int sphericart::cuda::adjust_shared_memory(
     bool requires_hessian,
     int64_t current_shared_mem_alloc
 ) {
-    int device;
-    cudaGetDevice(&device);
+
+    int device_count;
+
+    cudaGetDeviceCount(&device_count);
+
+    int current_device;
+    cudaGetDevice(&current_device);
 
     cudaDeviceProp deviceProp;
-    cudaGetDeviceProperties(&deviceProp, device);
+    cudaGetDeviceProperties(&deviceProp, current_device);
 
     auto required_buff_size = total_buffer_size(
         l_max, GRID_DIM_X, GRID_DIM_Y, element_size, requires_grad, requires_hessian
@@ -717,22 +722,30 @@ int sphericart::cuda::adjust_shared_memory(
             return -1; // failure - need to adjust parameters
         }
 
-        switch (element_size) {
-        case 8:
-            cudaFuncSetAttribute(
-                spherical_harmonics_kernel<double>,
-                cudaFuncAttributeMaxDynamicSharedMemorySize,
-                required_buff_size
-            );
-            break;
-        case 4:
-            cudaFuncSetAttribute(
-                spherical_harmonics_kernel<float>,
-                cudaFuncAttributeMaxDynamicSharedMemorySize,
-                required_buff_size
-            );
-            break;
+        // broadcast changes to all visible GPUs
+        for (int device = 0; device < device_count; device++) {
+
+            CUDA_CHECK(cudaSetDevice(device));
+
+            switch (element_size) {
+            case 8:
+                cudaFuncSetAttribute(
+                    spherical_harmonics_kernel<double>,
+                    cudaFuncAttributeMaxDynamicSharedMemorySize,
+                    required_buff_size
+                );
+                break;
+            case 4:
+                cudaFuncSetAttribute(
+                    spherical_harmonics_kernel<float>,
+                    cudaFuncAttributeMaxDynamicSharedMemorySize,
+                    required_buff_size
+                );
+                break;
+            }
         }
+
+        CUDA_CHECK(cudaSetDevice(current_device));
 
         return required_buff_size;
 

--- a/sphericart/src/sphericart_cuda.cu
+++ b/sphericart/src/sphericart_cuda.cu
@@ -38,14 +38,29 @@ template <typename T> SphericalHarmonics<T>::SphericalHarmonics(size_t l_max, bo
 
     // compute prefactors on host first
     compute_sph_prefactors<T>((int)l_max, this->prefactors_cpu);
-    // allocate them on device and copy to device
-    CUDA_CHECK(cudaMalloc((void**)&this->prefactors_cuda, this->nprefactors * sizeof(T)));
 
-    CUDA_CHECK(cudaMemcpy(
-        this->prefactors_cuda, this->prefactors_cpu, this->nprefactors * sizeof(T), cudaMemcpyHostToDevice
-    ));
+    CUDA_CHECK(cudaGetDeviceCount(&this->device_count));
 
-    // initialise the currently available amount of shared memory.
+    int current_device;
+
+    CUDA_CHECK(cudaGetDevice(&current_device));
+
+    // allocate prefactorts on every visible device and copy from host
+    this->prefactors_cuda = new T*[this->device_count];
+
+    for (int device = 0; device < this->device_count; device++) {
+        CUDA_CHECK(cudaSetDevice(device));
+        CUDA_CHECK(cudaMalloc((void**)&this->prefactors_cuda[device], this->nprefactors * sizeof(T))
+        );
+        CUDA_CHECK(cudaMemcpy(
+            this->prefactors_cuda[device],
+            this->prefactors_cpu,
+            this->nprefactors * sizeof(T),
+            cudaMemcpyHostToDevice
+        ));
+    }
+
+    // initialise the currently available amount of shared memory on all visible devices
     this->_current_shared_mem_allocation = adjust_shared_memory(
         sizeof(T),
         this->l_max,
@@ -55,13 +70,26 @@ template <typename T> SphericalHarmonics<T>::SphericalHarmonics(size_t l_max, bo
         false,
         this->_current_shared_mem_allocation
     );
+
+    // set the context back to the current device
+    CUDA_CHECK(cudaSetDevice(current_device));
 }
 
 template <typename T> SphericalHarmonics<T>::~SphericalHarmonics() {
     // Destructor, frees the prefactors
     delete[] (this->prefactors_cpu);
-    CUDA_CHECK(cudaDeviceSynchronize());
-    CUDA_CHECK(cudaFree(this->prefactors_cuda));
+
+    int current_device;
+
+    CUDA_CHECK(cudaGetDevice(&current_device));
+
+    for (int device = 0; device < this->device_count; device++) {
+        CUDA_CHECK(cudaSetDevice(device));
+        CUDA_CHECK(cudaDeviceSynchronize());
+        CUDA_CHECK(cudaFree(this->prefactors_cuda[device]));
+    }
+
+    CUDA_CHECK(cudaSetDevice(current_device));
 }
 
 template <typename T>
@@ -134,10 +162,14 @@ void SphericalHarmonics<T>::compute(
         this->cached_compute_with_hessian = compute_with_hessian;
     }
 
+    cudaPointerAttributes attributes;
+
+    CUDA_CHECK(cudaPointerGetAttributes(&attributes, xyz));
+
     sphericart::cuda::spherical_harmonics_cuda_base<T>(
         xyz,
         nsamples,
-        this->prefactors_cuda,
+        this->prefactors_cuda[attributes.device],
         this->nprefactors,
         this->l_max,
         this->normalized,

--- a/sphericart/src/sphericart_cuda.cu
+++ b/sphericart/src/sphericart_cuda.cu
@@ -166,6 +166,14 @@ void SphericalHarmonics<T>::compute(
 
     CUDA_CHECK(cudaPointerGetAttributes(&attributes, xyz));
 
+    int current_device;
+
+    CUDA_CHECK(cudaGetDevice(&current_device));
+
+    if (current_device != attributes.device) {
+        CUDA_CHECK(cudaSetDevice(attributes.device));
+    }
+
     sphericart::cuda::spherical_harmonics_cuda_base<T>(
         xyz,
         nsamples,

--- a/sphericart/src/sphericart_cuda.cu
+++ b/sphericart/src/sphericart_cuda.cu
@@ -190,6 +190,8 @@ void SphericalHarmonics<T>::compute(
         ddsph,
         cuda_stream
     );
+
+    CUDA_CHECK(cudaSetDevice(current_device));
 }
 
 // instantiates the SphericalHarmonics class for basic floating point types


### PR DESCRIPTION
This PR should fix allocating prefactors on every visible device, as well as broadcasting adjust_shared_memory onto every visible device.

In the compute code, it will determine the device that xyz is allocated on, and use the correct prefactor pointer as well as force a context switch to that device.