### PR TITLE
Remove MOPS leftover in `.clang-format`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -68,8 +68,6 @@ IndentWidth:     4
 IndentWrappedFunctionNames: false
 InsertBraces: true
 KeepEmptyLinesAtTheStartOfBlocks: true
-MacroBlockBegin: 'MOPS_CATCH_EXCEPTIONS_BEGIN'
-MacroBlockEnd:   'MOPS_CATCH_EXCEPTIONS_END'
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
 PenaltyBreakAssignment: 2


### PR DESCRIPTION
As the title says