### PR TITLE
Change `normalized` to `SphericalHarmonics` and `SolidHarmonics` across all APIs

### DIFF
--- a/benchmarks/cpp/benchmark.cpp
+++ b/benchmarks/cpp/benchmark.cpp
@@ -111,7 +111,7 @@ template <typename DTYPE> void run_timings(int l_max, int n_tries, int n_samples
     auto ddsph1 = std::vector<DTYPE>(n_samples * 9 * (l_max + 1) * (l_max + 1), 0.0);
 
     {
-        SphericalHarmonics<DTYPE> calculator(l_max, false);
+        SolidHarmonics<DTYPE> calculator(l_max);
         sxyz[0] = xyz[0];
         sxyz[1] = xyz[1];
         sxyz[2] = xyz[2];
@@ -143,7 +143,7 @@ template <typename DTYPE> void run_timings(int l_max, int n_tries, int n_samples
     }
 
     {
-        SphericalHarmonics<DTYPE> calculator(l_max, true);
+        SphericalHarmonics<DTYPE> calculator(l_max);
         benchmark("Call without derivatives (normalized)", n_samples, n_tries, [&]() {
             calculator.compute(xyz, sph1);
         });

--- a/docs/src/pytorch-api.rst
+++ b/docs/src/pytorch-api.rst
@@ -9,6 +9,10 @@ stored on, and its ``dtype``, the calculations will be performed
 using 32- or 64- bits floating point arythmetics, and
 using the CPU or CUDA implementation.
 
+In short, although the :py:class:`sphericart.SphericalHarmonics`
+class is technically not a ``torch.nn.Module``, it can be used in
+the same way.
+
 .. autoclass:: sphericart.torch.SphericalHarmonics
     :members:
 

--- a/examples/c/example.c
+++ b/examples/c/example.c
@@ -42,32 +42,36 @@ int main(int argc, char* argv[]) {
     /* ===== API calls ===== */
 
     // opaque pointer declaration: initializes buffers and numerical factors
-    sphericart_calculator_t* calculator = sphericart_new(l_max, 0);
+    sphericart_spherical_harmonics_calculator_t* calculator =
+        sphericart_spherical_harmonics_new(l_max);
 
     // function calls
     // without derivatives
-    sphericart_compute_array(calculator, xyz, 3 * n_samples, sph, sph_size);
+    sphericart_spherical_harmonics_compute_array(calculator, xyz, 3 * n_samples, sph, sph_size);
     // with derivatives
-    sphericart_compute_array_with_gradients(
+    sphericart_spherical_harmonics_compute_array_with_gradients(
         calculator, xyz, 3 * n_samples, sph, sph_size, dsph, dsph_size
     );
     // with second derivatives
-    sphericart_compute_array_with_hessians(
+    sphericart_spherical_harmonics_compute_array_with_hessians(
         calculator, xyz, 3 * n_samples, sph, sph_size, dsph, dsph_size, ddsph, ddsph_size
     );
 
     // per-sample calculation - we reuse the same arrays for simplicity, but
     // only the first item is computed
-    sphericart_compute_sample(calculator, xyz, 3, sph, sph_size);
-    sphericart_compute_sample_with_gradients(calculator, xyz, 3, sph, sph_size, dsph, dsph_size);
-    sphericart_compute_sample_with_hessians(
+    sphericart_spherical_harmonics_compute_sample(calculator, xyz, 3, sph, sph_size);
+    sphericart_spherical_harmonics_compute_sample_with_gradients(
+        calculator, xyz, 3, sph, sph_size, dsph, dsph_size
+    );
+    sphericart_spherical_harmonics_compute_sample_with_hessians(
         calculator, xyz, 3, sph, sph_size, dsph, dsph_size, ddsph, ddsph_size
     );
 
     // float version
-    sphericart_calculator_f_t* calculator_f = sphericart_new_f(l_max, 0);
+    sphericart_spherical_harmonics_calculator_f_t* calculator_f =
+        sphericart_spherical_harmonics_new_f(l_max);
 
-    sphericart_compute_array_with_gradients_f(
+    sphericart_spherical_harmonics_compute_array_with_gradients_f(
         calculator_f, xyz_f, 3 * n_samples, sph_f, sph_size, dsph_f, dsph_size
     );
 
@@ -83,12 +87,12 @@ int main(int argc, char* argv[]) {
     /* ===== clean up ===== */
 
     // frees up data arrays and sph object pointers
-    sphericart_delete(calculator);
+    sphericart_spherical_harmonics_delete(calculator);
     free(xyz);
     free(sph);
     free(dsph);
 
-    sphericart_delete_f(calculator_f);
+    sphericart_spherical_harmonics_delete_f(calculator_f);
     free(xyz_f);
     free(sph_f);
     free(dsph_f);

--- a/examples/jax/example.py
+++ b/examples/jax/example.py
@@ -6,63 +6,58 @@ import sphericart.jax
 key = jax.random.PRNGKey(0)
 xyz = 6 * jax.random.normal(key, (10, 3))
 l_max = 3  # set l_max to 3
-normalized = True  # in this example, we always compute normalized spherical harmonics
 
-# calculate the spherical harmonics with the corresponding function
-sph = sphericart.jax.spherical_harmonics(xyz, l_max, normalized)
+# calculate the spherical harmonics with the corresponding function,
+# we could also compute the solid harmonics with sphericart.jax.solid_harmonics
+sph = sphericart.jax.spherical_harmonics(xyz, l_max)
 
 # jit the function with jax.jit()
-# the l_max and normalized arguments (positions 1 and 2 in the signature) must be static
-jitted_sph_function = jax.jit(sphericart.jax.spherical_harmonics, static_argnums=(1, 2))
+# the l_max argument (position 1 in the signature) must be static
+jitted_sph_function = jax.jit(sphericart.jax.spherical_harmonics, static_argnums=(1,))
 
 # compute the spherical harmonics with the jitted function and check their values
 # against the non-jitted version
-jitted_sph = jitted_sph_function(xyz, l_max, normalized)
+jitted_sph = jitted_sph_function(xyz, l_max)
 assert jax.numpy.allclose(sph, jitted_sph)
 
 
 # calculate a scalar function of the spherical harmonics and take its gradient
 # with respect to the input Cartesian coordinates, as well as its hessian
-def scalar_output(xyz, l_max, normalized):
-    return jax.numpy.sum(sphericart.jax.spherical_harmonics(xyz, l_max, normalized))
+def scalar_output(xyz, l_max):
+    return jax.numpy.sum(sphericart.jax.spherical_harmonics(xyz, l_max))
 
-
-grad = jax.grad(scalar_output)(xyz, l_max, normalized)
+grad = jax.grad(scalar_output)(xyz, l_max)
 
 # NB: this computes a (n_samples,3,n_samples,3) hessian, i.e. includes cross terms
 # between samples.
-hessian = jax.hessian(scalar_output)(xyz, l_max, normalized)
+hessian = jax.hessian(scalar_output)(xyz, l_max)
 
-# usually you want a (n_samples,3,3), taking derivatives wrt the coordinates
-# of the same sample. one way to achieve this is as follows
+# usually you want a hessian in the shape (n_samples, 3, 3), taking derivatives
+# wrt the coordinates of the same sample. one way to achieve this is as follows
 
+def single_scalar_output(xyz, l_max):
+    return jax.numpy.sum(sphericart.jax.spherical_harmonics(xyz, l_max))
 
-def single_scalar_output(xyz, l_max, normalized):
-    return jax.numpy.sum(sphericart.jax.spherical_harmonics(xyz, l_max, normalized))
-
-
-# Compute the Hessian for a single (3,) input
+# define a function that computes the Hessian for a single (3,) input
 single_hessian = jax.hessian(single_scalar_output)
 
-# Use vmap to vectorize the Hessian computation over the first axis
-sh_hess = jax.vmap(single_hessian, in_axes=(0, None, None))
+# use vmap to vectorize the Hessian computation over the first axis
+sh_hess = jax.vmap(single_hessian, in_axes=(0, None))
 
 
 # calculate a function of the spherical harmonics that returns an array
 # and take its jacobian with respect to the input Cartesian coordinates,
 # both in forward mode and in reverse mode
-def array_output(xyz, l_max, normalized):
+def array_output(xyz, l_max):
     return jax.numpy.sum(
-        sphericart.jax.spherical_harmonics(xyz, l_max, normalized), axis=0
+        sphericart.jax.spherical_harmonics(xyz, l_max), axis=0
     )
 
-
-jacfwd = jax.jacfwd(array_output)(xyz, l_max, normalized)
-jacrev = jax.jacrev(array_output)(xyz, l_max, normalized)
-assert jax.numpy.allclose(jacfwd, jacrev)  # check that the two are the same
+jacfwd = jax.jacfwd(array_output)(xyz, l_max)
+jacrev = jax.jacrev(array_output)(xyz, l_max)
 
 # use vmap and compare the result with the original result:
-vmapped_sph = jax.vmap(sphericart.jax.spherical_harmonics, in_axes=(0, None, None))(
-    xyz, l_max, normalized
+vmapped_sph = jax.vmap(sphericart.jax.spherical_harmonics, in_axes=(0, None))(
+    xyz, l_max
 )
 assert jax.numpy.allclose(sph, vmapped_sph)

--- a/examples/python/example.py
+++ b/examples/python/example.py
@@ -29,9 +29,10 @@ def sphericart_example(l_max=10, n_samples=10000, solid=False):
     # ===== API calls =====
 
     if solid:
-        sh_calculator = sphericart.SphericalHarmonics(l_max)
-    else:
         sh_calculator = sphericart.SolidHarmonics(l_max)
+    else:
+        sh_calculator = sphericart.SphericalHarmonics(l_max)
+        
 
     # without gradients
     sh_sphericart = sh_calculator.compute(xyz)

--- a/examples/python/example.py
+++ b/examples/python/example.py
@@ -12,11 +12,10 @@ array of random 3D points, using both 32-bit and 64-bit arithmetics.
 """
 
 
-def sphericart_example(l_max=10, n_samples=10000, solid=False):
+def sphericart_example(l_max=10, n_samples=10000):
     # `sphericart` provides a SphericalHarmonics object that initializes the
     # calculation and then can be called on any n x 3 arrays of Cartesian
-    # coordinates. It computes _all_ SPH up to a given l_max, and can compute
-    # scaled (default) and solid (standard Ylm) harmonics.
+    # coordinates. It computes _all_ SPH up to a given l_max.
 
     # ===== set up the calculation =====
 
@@ -27,12 +26,8 @@ def sphericart_example(l_max=10, n_samples=10000, solid=False):
     xyz_f = np.array(xyz, dtype=np.float32)
 
     # ===== API calls =====
-
-    if solid:
-        sh_calculator = sphericart.SolidHarmonics(l_max)
-    else:
-        sh_calculator = sphericart.SphericalHarmonics(l_max)
-        
+    # we could also compute the solid harmonics with sphericart.SolidHarmonics
+    sh_calculator = sphericart.SphericalHarmonics(l_max)
 
     # without gradients
     sh_sphericart = sh_calculator.compute(xyz)
@@ -66,14 +61,8 @@ if __name__ == "__main__":
 
     parser.add_argument("-l", type=int, default=10, help="maximum angular momentum")
     parser.add_argument("-s", type=int, default=1000, help="number of samples")
-    parser.add_argument(
-        "--solid",
-        action="store_true",
-        default=False,
-        help="compute solid harmonics as opposed to the standard spherical harmonics",
-    )
 
     args = parser.parse_args()
 
     # Process everything.
-    sphericart_example(args.l, args.s, args.solid)
+    sphericart_example(args.l, args.s)

--- a/examples/python/example.py
+++ b/examples/python/example.py
@@ -12,11 +12,11 @@ array of random 3D points, using both 32-bit and 64-bit arithmetics.
 """
 
 
-def sphericart_example(l_max=10, n_samples=10000, normalized=False):
+def sphericart_example(l_max=10, n_samples=10000, solid=False):
     # `sphericart` provides a SphericalHarmonics object that initializes the
     # calculation and then can be called on any n x 3 arrays of Cartesian
     # coordinates. It computes _all_ SPH up to a given l_max, and can compute
-    # scaled (default) and normalized (standard Ylm) harmonics.
+    # scaled (default) and solid (standard Ylm) harmonics.
 
     # ===== set up the calculation =====
 
@@ -28,7 +28,10 @@ def sphericart_example(l_max=10, n_samples=10000, normalized=False):
 
     # ===== API calls =====
 
-    sh_calculator = sphericart.SphericalHarmonics(l_max, normalized=normalized)
+    if solid:
+        sh_calculator = sphericart.SphericalHarmonics(l_max)
+    else:
+        sh_calculator = sphericart.SolidHarmonics(l_max)
 
     # without gradients
     sh_sphericart = sh_calculator.compute(xyz)
@@ -63,13 +66,13 @@ if __name__ == "__main__":
     parser.add_argument("-l", type=int, default=10, help="maximum angular momentum")
     parser.add_argument("-s", type=int, default=1000, help="number of samples")
     parser.add_argument(
-        "--normalized",
+        "--solid",
         action="store_true",
         default=False,
-        help="compute normalized spherical harmonics",
+        help="compute solid harmonics as opposed to the standard spherical harmonics",
     )
 
     args = parser.parse_args()
 
     # Process everything.
-    sphericart_example(args.l, args.s, args.normalized)
+    sphericart_example(args.l, args.s, args.solid)

--- a/examples/pytorch/example.py
+++ b/examples/pytorch/example.py
@@ -19,7 +19,10 @@ class SHModule(torch.nn.Module):
     `torch.nn.Module`"""
 
     def __init__(self, l_max, normalized=False):
-        self.spherical_harmonics = sphericart.torch.SphericalHarmonics(l_max, normalized)
+        if normalized:
+            self.spherical_harmonics = sphericart.torch.SphericalHarmonics(l_max)
+        else:
+            self.spherical_harmonics = sphericart.torch.SolidHarmonics(l_max)
         super().__init__()
 
     def forward(self, xyz):
@@ -43,7 +46,10 @@ def sphericart_example(l_max=10, n_samples=10000, normalized=False):
 
     # ===== API calls =====
 
-    sh_calculator = sphericart.torch.SphericalHarmonics(l_max, normalized=normalized)
+    if normalized:
+        sh_calculator = sphericart.torch.SphericalHarmonics(l_max)
+    else:
+        sh_calculator = sphericart.torch.SolidHarmonics(l_max)
 
     # the interface allows to return directly the forward derivatives (up to second
     # order), similar to the Python version
@@ -91,9 +97,14 @@ def sphericart_example(l_max=10, n_samples=10000, normalized=False):
 
     # double derivatives. In order to access them via back-propagation, an additional
     # flag must be specified at class instantiation:
-    sh_calculator_2 = sphericart.torch.SphericalHarmonics(
-        l_max, normalized=normalized, backward_second_derivatives=True
-    )
+    if normalized:
+        sh_calculator_2 = sphericart.torch.SphericalHarmonics(
+            l_max, backward_second_derivatives=True
+        )
+    else:
+        sh_calculator_2 = sphericart.torch.SolidHarmonics(
+            l_max, backward_second_derivatives=True
+        )
 
     # double grad() call:
     xyz_ag2 = xyz[:5].clone().detach().type(torch.float64).to("cpu").requires_grad_()

--- a/examples/pytorch/example.py
+++ b/examples/pytorch/example.py
@@ -18,11 +18,9 @@ class SHModule(torch.nn.Module):
     """Example of how to use SphericalHarmonics from within a
     `torch.nn.Module`"""
 
-    def __init__(self, l_max, normalized=False):
-        if normalized:
-            self.spherical_harmonics = sphericart.torch.SphericalHarmonics(l_max)
-        else:
-            self.spherical_harmonics = sphericart.torch.SolidHarmonics(l_max)
+    def __init__(self, l_max):
+        self.spherical_harmonics = sphericart.torch.SphericalHarmonics(l_max)
+        # or SolidHarmonics if we wanted to compute solid harmonics
         super().__init__()
 
     def forward(self, xyz):
@@ -30,11 +28,10 @@ class SHModule(torch.nn.Module):
         return sh
 
 
-def sphericart_example(l_max=10, n_samples=10000, normalized=False):
+def sphericart_example(l_max=10, n_samples=10000):
     # `sphericart` provides a SphericalHarmonics object that initializes the
     # calculation and then can be called on any n x 3 arrays of Cartesian
-    # coordinates. It computes _all_ SPH up to a given l_max, and can compute
-    # scaled (default) and normalized (standard Ylm) harmonics.
+    # coordinates. It computes _all_ SPH up to a given l_max.
 
     # ===== set up the calculation =====
 
@@ -46,10 +43,7 @@ def sphericart_example(l_max=10, n_samples=10000, normalized=False):
 
     # ===== API calls =====
 
-    if normalized:
-        sh_calculator = sphericart.torch.SphericalHarmonics(l_max)
-    else:
-        sh_calculator = sphericart.torch.SolidHarmonics(l_max)
+    sh_calculator = sphericart.torch.SphericalHarmonics(l_max)
 
     # the interface allows to return directly the forward derivatives (up to second
     # order), similar to the Python version
@@ -97,14 +91,9 @@ def sphericart_example(l_max=10, n_samples=10000, normalized=False):
 
     # double derivatives. In order to access them via back-propagation, an additional
     # flag must be specified at class instantiation:
-    if normalized:
-        sh_calculator_2 = sphericart.torch.SphericalHarmonics(
-            l_max, backward_second_derivatives=True
-        )
-    else:
-        sh_calculator_2 = sphericart.torch.SolidHarmonics(
-            l_max, backward_second_derivatives=True
-        )
+    sh_calculator_2 = sphericart.torch.SphericalHarmonics(
+        l_max, backward_second_derivatives=True
+    )
 
     # double grad() call:
     xyz_ag2 = xyz[:5].clone().detach().type(torch.float64).to("cpu").requires_grad_()
@@ -127,7 +116,7 @@ def sphericart_example(l_max=10, n_samples=10000, normalized=False):
     # ===== torchscript integration =====
     xyz_jit = xyz.clone().detach().type(torch.float64).to("cpu").requires_grad_()
 
-    module = SHModule(l_max, normalized)
+    module = SHModule(l_max)
 
     # JIT compilation of the module
     script = torch.jit.script(module)
@@ -168,14 +157,8 @@ if __name__ == "__main__":
 
     parser.add_argument("-l", type=int, default=10, help="maximum angular momentum")
     parser.add_argument("-s", type=int, default=1000, help="number of samples")
-    parser.add_argument(
-        "--normalized",
-        action="store_true",
-        default=False,
-        help="compute normalized spherical harmonics",
-    )
 
     args = parser.parse_args()
 
     # Process everything.
-    sphericart_example(args.l, args.s, args.normalized)
+    sphericart_example(args.l, args.s)

--- a/examples/pytorch/example.py
+++ b/examples/pytorch/example.py
@@ -19,12 +19,12 @@ class SHModule(torch.nn.Module):
     `torch.nn.Module`"""
 
     def __init__(self, l_max, normalized=False):
-        self._sph = sphericart.torch.SphericalHarmonics(l_max, normalized)
+        self.spherical_harmonics = sphericart.torch.SphericalHarmonics(l_max, normalized)
         super().__init__()
 
     def forward(self, xyz):
-        sph = self._sph.compute(xyz)
-        return sph
+        sh = self.spherical_harmonics(xyz)  # or self.spherical_harmonics.compute(xyz)
+        return sh
 
 
 def sphericart_example(l_max=10, n_samples=10000, normalized=False):
@@ -47,7 +47,7 @@ def sphericart_example(l_max=10, n_samples=10000, normalized=False):
 
     # the interface allows to return directly the forward derivatives (up to second
     # order), similar to the Python version
-    sh_sphericart = sh_calculator.compute(xyz)
+    sh_sphericart = sh_calculator.compute(xyz)  # same as sh_calculator(xyz)
     sh_sphericart, dsh_sphericart = sh_calculator.compute_with_gradients(xyz)
     (
         sh_sphericart,

--- a/python/src/sphericart/__init__.py
+++ b/python/src/sphericart/__init__.py
@@ -1,1 +1,1 @@
-from .spherical_harmonics import SphericalHarmonics  # noqa
+from .spherical_harmonics import SphericalHarmonics, SolidHarmonics  # noqa

--- a/python/src/sphericart/_c_lib.py
+++ b/python/src/sphericart/_c_lib.py
@@ -6,58 +6,59 @@ import sys
 _HERE = os.path.realpath(os.path.dirname(__file__))
 
 
-class sphericart_calculator_t(ctypes.c_void_p):
+class sphericart_spherical_harmonics_calculator_t(ctypes.c_void_p):
     pass
 
 
-class sphericart_calculator_f_t(ctypes.c_void_p):
+class sphericart_spherical_harmonics_calculator_f_t(ctypes.c_void_p):
+    pass
+
+
+class sphericart_solid_harmonics_calculator_t(ctypes.c_void_p):
+    pass
+
+
+class sphericart_solid_harmonics_calculator_f_t(ctypes.c_void_p):
     pass
 
 
 def setup_functions(lib):
-    lib.sphericart_new.restype = sphericart_calculator_t
-    lib.sphericart_new.argtypes = [
-        ctypes.c_size_t,
-        ctypes.c_bool,
-    ]
-
-    lib.sphericart_new_f.restype = sphericart_calculator_f_t
-    lib.sphericart_new_f.argtypes = [
-        ctypes.c_size_t,
-        ctypes.c_bool,
-    ]
-
-    lib.sphericart_delete.restype = None
-    lib.sphericart_delete.argtypes = [sphericart_calculator_t]
-
-    lib.sphericart_delete_f.restype = None
-    lib.sphericart_delete_f.argtypes = [sphericart_calculator_f_t]
-
-    lib.sphericart_compute_array.restype = None
-    lib.sphericart_compute_array.argtypes = [
-        sphericart_calculator_t,
-        ctypes.POINTER(ctypes.c_double),
-        ctypes.c_size_t,
-        ctypes.POINTER(ctypes.c_double),
+    lib.sphericart_spherical_harmonics_new.restype = (
+        sphericart_spherical_harmonics_calculator_t
+    )
+    lib.sphericart_spherical_harmonics_new.argtypes = [
         ctypes.c_size_t,
     ]
 
-    lib.sphericart_compute_array_with_gradients.restype = None
-    lib.sphericart_compute_array_with_gradients.argtypes = [
-        sphericart_calculator_t,
-        ctypes.POINTER(ctypes.c_double),
+    lib.sphericart_spherical_harmonics_new_f.restype = (
+        sphericart_spherical_harmonics_calculator_f_t
+    )
+    lib.sphericart_spherical_harmonics_new_f.argtypes = [
         ctypes.c_size_t,
+    ]
+
+    lib.sphericart_spherical_harmonics_delete.restype = None
+    lib.sphericart_spherical_harmonics_delete.argtypes = [
+        sphericart_spherical_harmonics_calculator_t
+    ]
+
+    lib.sphericart_spherical_harmonics_delete_f.restype = None
+    lib.sphericart_spherical_harmonics_delete_f.argtypes = [
+        sphericart_spherical_harmonics_calculator_f_t
+    ]
+
+    lib.sphericart_spherical_harmonics_compute_array.restype = None
+    lib.sphericart_spherical_harmonics_compute_array.argtypes = [
+        sphericart_spherical_harmonics_calculator_t,
         ctypes.POINTER(ctypes.c_double),
         ctypes.c_size_t,
         ctypes.POINTER(ctypes.c_double),
         ctypes.c_size_t,
     ]
 
-    lib.sphericart_compute_array_with_hessians.restype = None
-    lib.sphericart_compute_array_with_hessians.argtypes = [
-        sphericart_calculator_t,
-        ctypes.POINTER(ctypes.c_double),
-        ctypes.c_size_t,
+    lib.sphericart_spherical_harmonics_compute_array_with_gradients.restype = None
+    lib.sphericart_spherical_harmonics_compute_array_with_gradients.argtypes = [
+        sphericart_spherical_harmonics_calculator_t,
         ctypes.POINTER(ctypes.c_double),
         ctypes.c_size_t,
         ctypes.POINTER(ctypes.c_double),
@@ -66,18 +67,31 @@ def setup_functions(lib):
         ctypes.c_size_t,
     ]
 
-    lib.sphericart_compute_array_f.restype = None
-    lib.sphericart_compute_array_f.argtypes = [
-        sphericart_calculator_f_t,
+    lib.sphericart_spherical_harmonics_compute_array_with_hessians.restype = None
+    lib.sphericart_spherical_harmonics_compute_array_with_hessians.argtypes = [
+        sphericart_spherical_harmonics_calculator_t,
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.c_size_t,
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.c_size_t,
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.c_size_t,
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.c_size_t,
+    ]
+
+    lib.sphericart_spherical_harmonics_compute_array_f.restype = None
+    lib.sphericart_spherical_harmonics_compute_array_f.argtypes = [
+        sphericart_spherical_harmonics_calculator_f_t,
         ctypes.POINTER(ctypes.c_float),
         ctypes.c_size_t,
         ctypes.POINTER(ctypes.c_float),
         ctypes.c_size_t,
     ]
 
-    lib.sphericart_compute_array_with_gradients_f.restype = None
-    lib.sphericart_compute_array_with_gradients_f.argtypes = [
-        sphericart_calculator_f_t,
+    lib.sphericart_spherical_harmonics_compute_array_with_gradients_f.restype = None
+    lib.sphericart_spherical_harmonics_compute_array_with_gradients_f.argtypes = [
+        sphericart_spherical_harmonics_calculator_f_t,
         ctypes.POINTER(ctypes.c_float),
         ctypes.c_size_t,
         ctypes.POINTER(ctypes.c_float),
@@ -86,9 +100,9 @@ def setup_functions(lib):
         ctypes.c_size_t,
     ]
 
-    lib.sphericart_compute_array_with_hessians_f.restype = None
-    lib.sphericart_compute_array_with_hessians_f.argtypes = [
-        sphericart_calculator_f_t,
+    lib.sphericart_spherical_harmonics_compute_array_with_hessians_f.restype = None
+    lib.sphericart_spherical_harmonics_compute_array_with_hessians_f.argtypes = [
+        sphericart_spherical_harmonics_calculator_f_t,
         ctypes.POINTER(ctypes.c_float),
         ctypes.c_size_t,
         ctypes.POINTER(ctypes.c_float),
@@ -99,14 +113,112 @@ def setup_functions(lib):
         ctypes.c_size_t,
     ]
 
-    lib.sphericart_omp_num_threads.restype = int
-    lib.sphericart_omp_num_threads.argtypes = [
-        sphericart_calculator_t,
+    lib.sphericart_spherical_harmonics_omp_num_threads.restype = int
+    lib.sphericart_spherical_harmonics_omp_num_threads.argtypes = [
+        sphericart_spherical_harmonics_calculator_t,
     ]
 
-    lib.sphericart_omp_num_threads_f.restype = int
-    lib.sphericart_omp_num_threads_f.argtypes = [
-        sphericart_calculator_f_t,
+    lib.sphericart_spherical_harmonics_omp_num_threads_f.restype = int
+    lib.sphericart_spherical_harmonics_omp_num_threads_f.argtypes = [
+        sphericart_spherical_harmonics_calculator_f_t,
+    ]
+
+    lib.sphericart_solid_harmonics_new.restype = sphericart_solid_harmonics_calculator_t
+    lib.sphericart_solid_harmonics_new.argtypes = [
+        ctypes.c_size_t,
+    ]
+
+    lib.sphericart_solid_harmonics_new_f.restype = (
+        sphericart_solid_harmonics_calculator_f_t
+    )
+    lib.sphericart_solid_harmonics_new_f.argtypes = [
+        ctypes.c_size_t,
+    ]
+
+    lib.sphericart_solid_harmonics_delete.restype = None
+    lib.sphericart_solid_harmonics_delete.argtypes = [
+        sphericart_solid_harmonics_calculator_t
+    ]
+
+    lib.sphericart_solid_harmonics_delete_f.restype = None
+    lib.sphericart_solid_harmonics_delete_f.argtypes = [
+        sphericart_solid_harmonics_calculator_f_t
+    ]
+
+    lib.sphericart_solid_harmonics_compute_array.restype = None
+    lib.sphericart_solid_harmonics_compute_array.argtypes = [
+        sphericart_solid_harmonics_calculator_t,
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.c_size_t,
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.c_size_t,
+    ]
+
+    lib.sphericart_solid_harmonics_compute_array_with_gradients.restype = None
+    lib.sphericart_solid_harmonics_compute_array_with_gradients.argtypes = [
+        sphericart_solid_harmonics_calculator_t,
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.c_size_t,
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.c_size_t,
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.c_size_t,
+    ]
+
+    lib.sphericart_solid_harmonics_compute_array_with_hessians.restype = None
+    lib.sphericart_solid_harmonics_compute_array_with_hessians.argtypes = [
+        sphericart_solid_harmonics_calculator_t,
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.c_size_t,
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.c_size_t,
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.c_size_t,
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.c_size_t,
+    ]
+
+    lib.sphericart_solid_harmonics_compute_array_f.restype = None
+    lib.sphericart_solid_harmonics_compute_array_f.argtypes = [
+        sphericart_solid_harmonics_calculator_f_t,
+        ctypes.POINTER(ctypes.c_float),
+        ctypes.c_size_t,
+        ctypes.POINTER(ctypes.c_float),
+        ctypes.c_size_t,
+    ]
+
+    lib.sphericart_solid_harmonics_compute_array_with_gradients_f.restype = None
+    lib.sphericart_solid_harmonics_compute_array_with_gradients_f.argtypes = [
+        sphericart_solid_harmonics_calculator_f_t,
+        ctypes.POINTER(ctypes.c_float),
+        ctypes.c_size_t,
+        ctypes.POINTER(ctypes.c_float),
+        ctypes.c_size_t,
+        ctypes.POINTER(ctypes.c_float),
+        ctypes.c_size_t,
+    ]
+
+    lib.sphericart_solid_harmonics_compute_array_with_hessians_f.restype = None
+    lib.sphericart_solid_harmonics_compute_array_with_hessians_f.argtypes = [
+        sphericart_solid_harmonics_calculator_f_t,
+        ctypes.POINTER(ctypes.c_float),
+        ctypes.c_size_t,
+        ctypes.POINTER(ctypes.c_float),
+        ctypes.c_size_t,
+        ctypes.POINTER(ctypes.c_float),
+        ctypes.c_size_t,
+        ctypes.POINTER(ctypes.c_float),
+        ctypes.c_size_t,
+    ]
+
+    lib.sphericart_solid_harmonics_omp_num_threads.restype = int
+    lib.sphericart_solid_harmonics_omp_num_threads.argtypes = [
+        sphericart_solid_harmonics_calculator_t,
+    ]
+
+    lib.sphericart_solid_harmonics_omp_num_threads_f.restype = int
+    lib.sphericart_solid_harmonics_omp_num_threads_f.argtypes = [
+        sphericart_solid_harmonics_calculator_f_t,
     ]
 
 

--- a/python/tests/test_no_points.py
+++ b/python/tests/test_no_points.py
@@ -9,6 +9,9 @@ import sphericart
 def test_no_points(l_max, normalized):
     xyz = np.empty((0, 3))
 
-    calculator = sphericart.SphericalHarmonics(l_max, normalized=normalized)
+    if normalized:
+        calculator = sphericart.SphericalHarmonics(l_max)
+    else:
+        calculator = sphericart.SolidHarmonics(l_max)
     sph_sphericart = calculator.compute(xyz)
     assert sph_sphericart.shape == (0, l_max * l_max + 2 * l_max + 1)

--- a/python/tests/test_vs_scipy.py
+++ b/python/tests/test_vs_scipy.py
@@ -48,13 +48,13 @@ def test_against_scipy(xyz):
             y = xyz[:, 1]
             z = xyz[:, 2]
             r = np.sqrt(x**2 + y**2 + z**2)
-            calculator = sphericart.SphericalHarmonics(l)
+            calculator = sphericart.SolidHarmonics(l)
             sph_sphericart = calculator.compute(xyz)
             sph_sphericart_l_m = sph_sphericart[:, l * l + l + m] / r**l
 
             assert np.allclose(sph_scipy_l_m, sph_sphericart_l_m)
 
-            calculator = sphericart.SphericalHarmonics(l, normalized=True)
+            calculator = sphericart.SphericalHarmonics(l)
             sph_sphericart = calculator.compute(xyz)
             sph_normalized_l_m = sph_sphericart[:, l * l + l + m]
 
@@ -63,8 +63,10 @@ def test_against_scipy(xyz):
 
 def test_derivatives(xyz):
     delta = 1e-6
-    for normalized in [False, True]:
-        calculator = sphericart.SphericalHarmonics(L_MAX, normalized=normalized)
+    for calculator in [
+        sphericart.SphericalHarmonics(L_MAX),
+        sphericart.SolidHarmonics(L_MAX),
+    ]:
         for alpha in range(3):
             xyz_plus = xyz.copy()
             xyz_plus[:, alpha] += delta * np.ones_like(xyz[:, alpha])
@@ -80,8 +82,10 @@ def test_derivatives(xyz):
 
 def test_second_derivatives(xyz):
     delta = 1e-5
-    for normalized in [False, True]:
-        calculator = sphericart.SphericalHarmonics(L_MAX, normalized=normalized)
+    for calculator in [
+        sphericart.SphericalHarmonics(L_MAX),
+        sphericart.SolidHarmonics(L_MAX),
+    ]:
         for alpha in range(3):
             for beta in range(3):
                 xyz_plus_plus = xyz.copy()

--- a/sphericart-jax/include/sphericart/sphericart_jax_cuda.hpp
+++ b/sphericart-jax/include/sphericart/sphericart_jax_cuda.hpp
@@ -1,3 +1,6 @@
+// This file is needed as a workaround for pybind11 not accepting cuda files.
+// Note that all the templated functions are split into separate functions so
+// that they can be compiled in the `.cu` file.
 
 #ifndef _SPHERICART_JAX_CUDA_HPP_
 #define _SPHERICART_JAX_CUDA_HPP_
@@ -8,32 +11,35 @@
 struct SphDescriptor {
     std::int64_t n_samples;
     std::int64_t lmax;
-    bool normalize;
 };
 
 namespace sphericart_jax {
 
 namespace cuda {
 
-void apply_cuda_sph_f32(cudaStream_t stream, void** in, const char* opaque, std::size_t opaque_len);
+void cuda_spherical_f32(cudaStream_t stream, void** in, const char* opaque, std::size_t opaque_len);
 
-void apply_cuda_sph_f64(cudaStream_t stream, void** in, const char* opaque, std::size_t opaque_len);
+void cuda_spherical_f64(cudaStream_t stream, void** in, const char* opaque, std::size_t opaque_len);
 
-void apply_cuda_sph_with_gradients_f32(
-    cudaStream_t stream, void** in, const char* opaque, std::size_t opaque_len
-);
+void cuda_dspherical_f32(cudaStream_t stream, void** in, const char* opaque, std::size_t opaque_len);
 
-void apply_cuda_sph_with_gradients_f64(
-    cudaStream_t stream, void** in, const char* opaque, std::size_t opaque_len
-);
+void cuda_dspherical_f64(cudaStream_t stream, void** in, const char* opaque, std::size_t opaque_len);
 
-void apply_cuda_sph_with_hessians_f32(
-    cudaStream_t stream, void** in, const char* opaque, std::size_t opaque_len
-);
+void cuda_ddspherical_f32(cudaStream_t stream, void** in, const char* opaque, std::size_t opaque_len);
 
-void apply_cuda_sph_with_hessians_f64(
-    cudaStream_t stream, void** in, const char* opaque, std::size_t opaque_len
-);
+void cuda_ddspherical_f64(cudaStream_t stream, void** in, const char* opaque, std::size_t opaque_len);
+
+void cuda_solid_f32(cudaStream_t stream, void** in, const char* opaque, std::size_t opaque_len);
+
+void cuda_solid_f64(cudaStream_t stream, void** in, const char* opaque, std::size_t opaque_len);
+
+void cuda_dsolid_f32(cudaStream_t stream, void** in, const char* opaque, std::size_t opaque_len);
+
+void cuda_dsolid_f64(cudaStream_t stream, void** in, const char* opaque, std::size_t opaque_len);
+
+void cuda_ddsolid_f32(cudaStream_t stream, void** in, const char* opaque, std::size_t opaque_len);
+
+void cuda_ddsolid_f64(cudaStream_t stream, void** in, const char* opaque, std::size_t opaque_len);
 
 } // namespace cuda
 } // namespace sphericart_jax

--- a/sphericart-jax/python/sphericart/jax/__init__.py
+++ b/sphericart-jax/python/sphericart/jax/__init__.py
@@ -1,6 +1,6 @@
 import jax
 from .lib import sphericart_jax_cpu
-from .spherical_harmonics import spherical_harmonics
+from .spherical_harmonics import spherical_harmonics, solid_harmonics
 
 
 # register the operations to xla

--- a/sphericart-jax/python/sphericart/jax/ddsph.py
+++ b/sphericart-jax/python/sphericart/jax/ddsph.py
@@ -48,10 +48,15 @@ def ddsph_lowering_cpu(ctx, xyz, l_max, normalized, *, l_max_c, normalized_c):
     ddsph_shape = xyz_shape[:-1] + [3, 3, sph_size]
     n_samples = math.prod(xyz_shape[:-1])
 
+    op_name = "cpu_dd"
+    if normalized_c:
+        op_name += "spherical_"
+    else:
+        op_name += "solid_"
     if dtype == ir.F32Type.get():
-        op_name = "cpu_ddsph_f32"
+        op_name += "f32"
     elif dtype == ir.F64Type.get():
-        op_name = "cpu_ddsph_f64"
+        op_name += "f64"
     else:
         raise NotImplementedError(f"Unsupported dtype {dtype}")
 
@@ -65,10 +70,9 @@ def ddsph_lowering_cpu(ctx, xyz, l_max, normalized, *, l_max_c, normalized_c):
         operands=[
             xyz,
             mlir.ir_constant(l_max_c),
-            mlir.ir_constant(normalized_c),
             mlir.ir_constant(n_samples),
         ],
-        operand_layouts=default_layouts(xyz_shape, (), (), ()),
+        operand_layouts=default_layouts(xyz_shape, (), ()),
         result_layouts=default_layouts(sph_shape, dsph_shape, ddsph_shape),
     ).results
 
@@ -86,14 +90,19 @@ def ddsph_lowering_cuda(ctx, xyz, l_max, normalized, *, l_max_c, normalized_c):
     ddsph_shape = xyz_shape[:-1] + [3, 3, sph_size]
     n_samples = math.prod(xyz_shape[:-1])
 
+    op_name = "cuda_dd"
+    if normalized_c:
+        op_name += "spherical_"
+    else:
+        op_name += "solid_"
     if dtype == ir.F32Type.get():
-        op_name = "cuda_ddsph_f32"
+        op_name += "f32"
     elif dtype == ir.F64Type.get():
-        op_name = "cuda_ddsph_f64"
+        op_name += "f64"
     else:
         raise NotImplementedError(f"Unsupported dtype {dtype}")
 
-    descriptor = build_sph_descriptor(n_samples, l_max_c, normalized_c)
+    descriptor = build_sph_descriptor(n_samples, l_max_c)
 
     return custom_call(
         op_name,

--- a/sphericart-jax/python/sphericart/jax/dsph.py
+++ b/sphericart-jax/python/sphericart/jax/dsph.py
@@ -46,10 +46,15 @@ def dsph_lowering_cpu(ctx, xyz, l_max, normalized, *, l_max_c, normalized_c):
     dsph_shape = xyz_shape[:-1] + [3, sph_size]
     n_samples = math.prod(xyz_shape[:-1])
 
+    op_name = "cpu_d"
+    if normalized_c:
+        op_name += "spherical_"
+    else:
+        op_name += "solid_"
     if dtype == ir.F32Type.get():
-        op_name = "cpu_dsph_f32"
+        op_name += "f32"
     elif dtype == ir.F64Type.get():
-        op_name = "cpu_dsph_f64"
+        op_name += "f64"
     else:
         raise NotImplementedError(f"Unsupported dtype {dtype}")
 
@@ -62,10 +67,9 @@ def dsph_lowering_cpu(ctx, xyz, l_max, normalized, *, l_max_c, normalized_c):
         operands=[
             xyz,
             mlir.ir_constant(l_max_c),
-            mlir.ir_constant(normalized_c),
             mlir.ir_constant(n_samples),
         ],
-        operand_layouts=default_layouts(xyz_shape, (), (), ()),
+        operand_layouts=default_layouts(xyz_shape, (), ()),
         result_layouts=default_layouts(sph_shape, dsph_shape),
     ).results
 
@@ -82,14 +86,19 @@ def dsph_lowering_cuda(ctx, xyz, l_max, normalized, *, l_max_c, normalized_c):
     dsph_shape = xyz_shape[:-1] + [3, sph_size]
     n_samples = math.prod(xyz_shape[:-1])
 
+    op_name = "cuda_d"
+    if normalized_c:
+        op_name += "spherical_"
+    else:
+        op_name += "solid_"
     if dtype == ir.F32Type.get():
-        op_name = "cuda_dsph_f32"
+        op_name += "f32"
     elif dtype == ir.F64Type.get():
-        op_name = "cuda_dsph_f64"
+        op_name += "f64"
     else:
         raise NotImplementedError(f"Unsupported dtype {dtype}")
 
-    descriptor = build_sph_descriptor(n_samples, l_max_c, normalized_c)
+    descriptor = build_sph_descriptor(n_samples, l_max_c)
 
     return custom_call(
         op_name,

--- a/sphericart-jax/python/sphericart/jax/sph.py
+++ b/sphericart-jax/python/sphericart/jax/sph.py
@@ -50,10 +50,15 @@ def sph_lowering_cpu(ctx, xyz, l_max, normalized, *, l_max_c, normalized_c):
     n_samples = math.prod(xyz_shape[:-1])
 
     # make sure we dispatch to the correct implementation
+    op_name = "cpu_"
+    if normalized_c:
+        op_name += "spherical_"
+    else:
+        op_name += "solid_"
     if dtype == ir.F32Type.get():
-        op_name = "cpu_sph_f32"
+        op_name += "f32"
     elif dtype == ir.F64Type.get():
-        op_name = "cpu_sph_f64"
+        op_name += "f64"
     else:
         raise NotImplementedError(f"Unsupported dtype {dtype}")
 
@@ -67,11 +72,10 @@ def sph_lowering_cpu(ctx, xyz, l_max, normalized, *, l_max_c, normalized_c):
         operands=[
             xyz,
             mlir.ir_constant(l_max_c),
-            mlir.ir_constant(normalized_c),
             mlir.ir_constant(n_samples),
         ],
         # Layout specification:
-        operand_layouts=default_layouts(xyz_shape, (), (), ()),
+        operand_layouts=default_layouts(xyz_shape, (), ()),
         result_layouts=default_layouts(out_shape),
     ).results
 
@@ -93,14 +97,19 @@ def sph_lowering_cuda(ctx, xyz, l_max, normalized, *, l_max_c, normalized_c):
     n_samples = math.prod(xyz_shape[:-1])
 
     # make sure we dispatch to the correct implementation
+    op_name = "cuda_"
+    if normalized_c:
+        op_name += "spherical_"
+    else:
+        op_name += "solid_"
     if dtype == ir.F32Type.get():
-        op_name = "cuda_sph_f32"
+        op_name += "f32"
     elif dtype == ir.F64Type.get():
-        op_name = "cuda_sph_f64"
+        op_name += "f64"
     else:
         raise NotImplementedError(f"Unsupported dtype {dtype}")
 
-    descriptor = build_sph_descriptor(n_samples, l_max_c, normalized_c)
+    descriptor = build_sph_descriptor(n_samples, l_max_c)
     
     return custom_call(
         op_name,

--- a/sphericart-jax/python/sphericart/jax/spherical_harmonics.py
+++ b/sphericart-jax/python/sphericart/jax/spherical_harmonics.py
@@ -1,7 +1,7 @@
 from .sph import sph
 
 
-def spherical_harmonics(xyz, l_max, normalized=False):
+def spherical_harmonics(xyz, l_max):
     """Computes the Spherical harmonics and their derivatives within
     the JAX framework.
     
@@ -9,12 +9,12 @@ def spherical_harmonics(xyz, l_max, normalized=False):
     backward automatic differentiation (``grad``, ``jacfwd``, ``jacrev``, ``hessian``, ...).
     For the moment, it does not support ``pmap``.
 
-    Note that the ``l_max`` and ``normalized`` arguments (positions 1 and 2 in the signature)
-    should be tagged as static when jit-ing the function:
+    Note that the ``l_max`` argument (position 1 in the signature) should be tagged as static
+    when jit-ing the function:
 
     >>> import jax
     >>> import sphericart.jax
-    >>> jitted_sph_function = jax.jit(sphericart.jax.spherical_harmonics, static_argnums=(1, 2))
+    >>> jitted_sph_function = jax.jit(sphericart.jax.spherical_harmonics, static_argnums=1)
 
     Parameters
     ----------
@@ -22,9 +22,6 @@ def spherical_harmonics(xyz, l_max, normalized=False):
         single vector or set of vectors in 3D. All dimensions are optional except for the last
     l_max : int
         maximum order of the spherical harmonics (included)
-    normalized : bool
-        whether the function computes Cartesian solid harmonics (``normalized=False``, default)
-        or normalized spherical harmonicsi (``normalized=True``)
 
     Returns
     -------
@@ -34,5 +31,16 @@ def spherical_harmonics(xyz, l_max, normalized=False):
     if xyz.shape[-1] != 3:
         raise ValueError("the last axis of xyz must have size 3")
     xyz = xyz.ravel().reshape(xyz.shape)  # make contiguous (???)
-    output = sph(xyz, l_max, normalized)
+    output = sph(xyz, l_max, normalized=True)
+    return output
+
+
+def solid_harmonics(xyz, l_max, normalized=False):
+    """
+    Same as `spherical_harmonics`, but computes the solid harmonics instead.
+    """
+    if xyz.shape[-1] != 3:
+        raise ValueError("the last axis of xyz must have size 3")
+    xyz = xyz.ravel().reshape(xyz.shape)  # make contiguous (???)
+    output = sph(xyz, l_max, normalized=False)
     return output

--- a/sphericart-jax/python/sphericart/jax/utils.py
+++ b/sphericart-jax/python/sphericart/jax/utils.py
@@ -4,7 +4,7 @@ def default_layouts(*shapes):
 try:
     from .lib.sphericart_jax_cuda import build_sph_descriptor
 except ImportError:
-    def build_sph_descriptor(a, b, c):
+    def build_sph_descriptor(a, b):
         raise ValueError(
             "Trying to use sphericart-jax on CUDA, "
             "but sphericart-jax was installed without CUDA support. "

--- a/sphericart-jax/python/tests/test_autograd.py
+++ b/sphericart-jax/python/tests/test_autograd.py
@@ -2,7 +2,7 @@ import pytest
 import jax
 
 import jax.numpy as jnp
-import jax._src.test_util as jtu
+import jax.test_util as jtu
 import sphericart.jax
 
 
@@ -14,8 +14,9 @@ def test_autograd(normalized):
     key = jax.random.PRNGKey(0)
     xyz = 6 * jax.random.normal(key, (100, 3))
 
+    function = sphericart.jax.spherical_harmonics if normalized else sphericart.jax.solid_harmonics
     def compute(xyz):
-        sph = sphericart.jax.spherical_harmonics(xyz, 4, normalized)
+        sph = function(xyz, 4)
         return jnp.sum(sph)
 
     jtu.check_grads(compute, (xyz,), modes=["fwd", "bwd"], order=1)
@@ -32,8 +33,9 @@ def test_autograd_second_derivatives(normalized):
     key = jax.random.PRNGKey(0)
     xyz = 6 * jax.random.normal(key, (100, 3))
 
+    function = sphericart.jax.spherical_harmonics if normalized else sphericart.jax.solid_harmonics
     def compute(xyz):
-        sph = sphericart.jax.spherical_harmonics(xyz, 4, normalized)
+        sph = function(xyz, 4)
         return jnp.sum(sph)
 
     jtu.check_grads(compute, (xyz,), modes=["fwd", "bwd"], order=2)

--- a/sphericart-jax/python/tests/test_consistency.py
+++ b/sphericart-jax/python/tests/test_consistency.py
@@ -16,9 +16,14 @@ def xyz():
 @pytest.mark.parametrize("normalized", [False, True])
 @pytest.mark.parametrize("l_max", [4, 7, 10])
 def test_consistency(xyz, l_max, normalized):
-    calculator = sphericart.SphericalHarmonics(l_max=l_max, normalized=normalized)
-    sph = sphericart.jax.spherical_harmonics(
-        l_max=l_max, normalized=normalized, xyz=xyz
+    if normalized:
+        calculator = sphericart.SphericalHarmonics(l_max=l_max)
+    else:
+        calculator = sphericart.SolidHarmonics(l_max=l_max)
+
+    function = sphericart.jax.spherical_harmonics if normalized else sphericart.jax.solid_harmonics
+    sph = function(
+        l_max=l_max, xyz=xyz
     )
 
     sph_ref = calculator.compute(np.asarray(xyz))

--- a/sphericart-jax/python/tests/test_nn.py
+++ b/sphericart-jax/python/tests/test_nn.py
@@ -11,7 +11,7 @@ def test_nn():
             pass
 
         def __call__(self, xyz):
-            sph = sphericart.jax.spherical_harmonics(xyz, 4, True)
+            sph = sphericart.jax.spherical_harmonics(xyz, 4)
             sum = jnp.sum(sph)
             return sum
 

--- a/sphericart-jax/python/tests/test_no_points.py
+++ b/sphericart-jax/python/tests/test_no_points.py
@@ -9,7 +9,8 @@ import sphericart.jax
 def test_no_points(l_max, normalized):
     xyz = jnp.empty((0, 3))
 
-    sph = sphericart.jax.spherical_harmonics(
-        l_max=l_max, normalized=normalized, xyz=xyz
+    function = sphericart.jax.spherical_harmonics if normalized else sphericart.jax.solid_harmonics
+    sph = function(
+        l_max=l_max, xyz=xyz
     )
     assert sph.shape == (0, l_max * l_max + 2 * l_max + 1)

--- a/sphericart-jax/python/tests/test_precision.py
+++ b/sphericart-jax/python/tests/test_precision.py
@@ -15,7 +15,7 @@ def test_precision(xyz):
     jax.config.update("jax_enable_x64", True)
 
     def compute(xyz):
-        sph = sphericart.jax.spherical_harmonics(xyz, l_max=4, normalized=False)
+        sph = sphericart.jax.solid_harmonics(xyz, l_max=4)
         return sph
 
     xyz_64 = jnp.array(xyz, dtype=jnp.float64)

--- a/sphericart-jax/python/tests/test_pure_jax.py
+++ b/sphericart-jax/python/tests/test_pure_jax.py
@@ -15,9 +15,9 @@ def xyz():
 
 @pytest.mark.parametrize("l_max", [2, 7])
 def test_jit(xyz, l_max):
-    jitted_sph = jax.jit(sphericart.jax.spherical_harmonics, static_argnums=(1, 2))
+    jitted_sph = jax.jit(sphericart.jax.spherical_harmonics, static_argnums=(1,))
     pure_jax_jitted_sph = jax.jit(pure_jax_spherical_harmonics, static_argnums=1)
-    sph = jitted_sph(xyz=xyz, l_max=l_max, normalized=True)
+    sph = jitted_sph(xyz=xyz, l_max=l_max)
     sph_pure_jax = pure_jax_jitted_sph(xyz, l_max)
     assert jnp.allclose(sph, sph_pure_jax, atol=1e-5, rtol=1e-4)
 
@@ -26,7 +26,7 @@ def test_jit(xyz, l_max):
 def test_jacfwd(xyz, l_max):
     jacfwd_sph = jax.jacfwd(sphericart.jax.spherical_harmonics)
     pure_jax_jacfwd_sph = jax.jacfwd(pure_jax_spherical_harmonics)
-    sph = jacfwd_sph(xyz, l_max=l_max, normalized=True)
+    sph = jacfwd_sph(xyz, l_max=l_max)
     sph_pure_jax = pure_jax_jacfwd_sph(xyz, l_max)
     assert jnp.allclose(sph, sph_pure_jax, atol=1e-4, rtol=3e-4)
 
@@ -35,25 +35,25 @@ def test_jacfwd(xyz, l_max):
 def test_jacrev(xyz, l_max):
     jacrev_sph = jax.jacrev(sphericart.jax.spherical_harmonics)
     pure_jax_jacrev_sph = jax.jacrev(pure_jax_spherical_harmonics)
-    sph = jacrev_sph(xyz, l_max=l_max, normalized=True)
+    sph = jacrev_sph(xyz, l_max=l_max)
     sph_pure_jax = pure_jax_jacrev_sph(xyz, l_max)
     assert jnp.allclose(sph, sph_pure_jax, atol=1e-4, rtol=3e-4)
 
 
 @pytest.mark.parametrize("l_max", [2, 7])
 def test_gradgrad(xyz, l_max):
-    sum_sph = lambda x, l_max, normalized: jnp.sum(
-        sphericart.jax.spherical_harmonics(x, l_max, normalized)
+    sum_sph = lambda x, l_max: jnp.sum(
+        sphericart.jax.spherical_harmonics(x, l_max)
     )
     pure_jax_sum_sph = lambda x, l_max: jnp.sum(pure_jax_spherical_harmonics(x, l_max))
-    sum_grad_sph = lambda x, l_max, normalized: jnp.sum(
-        jax.grad(sum_sph)(x, l_max, normalized)
+    sum_grad_sph = lambda x, l_max: jnp.sum(
+        jax.grad(sum_sph)(x, l_max)
     )
     pure_jax_sum_grad_sph = lambda x, l_max: jnp.sum(
         jax.grad(pure_jax_sum_sph)(x, l_max)
     )
     gradgrad_sph = jax.grad(sum_grad_sph)
     pure_jax_gradgrad_sph = jax.grad(pure_jax_sum_grad_sph)
-    sph = gradgrad_sph(xyz, l_max, normalized=True)
+    sph = gradgrad_sph(xyz, l_max)
     sph_pure_jax = pure_jax_gradgrad_sph(xyz, l_max)
     assert jnp.allclose(sph, sph_pure_jax, atol=1e-4, rtol=3e-4)

--- a/sphericart-jax/python/tests/test_transforms.py
+++ b/sphericart-jax/python/tests/test_transforms.py
@@ -14,7 +14,7 @@ def xyz():
 
 def test_script(xyz):
     def compute(xyz):
-        sph = sphericart.jax.spherical_harmonics(l_max=4, normalized=False, xyz=xyz)
+        sph = sphericart.jax.solid_harmonics(l_max=4, xyz=xyz)
         return sph.sum()
 
     # jit compile the function
@@ -27,11 +27,13 @@ def test_script(xyz):
 @pytest.mark.parametrize("normalized", [True, False])
 @pytest.mark.parametrize("l_max", [4, 7, 10])
 def test_jit(xyz, l_max, normalized):
-    jitted_sph = jax.jit(sphericart.jax.spherical_harmonics, static_argnums=(1, 2))
-    calculator = sphericart.SphericalHarmonics(
-        l_max=l_max, normalized=normalized
-    )
-    sph = jitted_sph(xyz=xyz, l_max=l_max, normalized=normalized)
+    function = sphericart.jax.spherical_harmonics if normalized else sphericart.jax.solid_harmonics
+    jitted_sph = jax.jit(function, static_argnums=(1,))
+    if normalized:
+        calculator = sphericart.SphericalHarmonics(l_max=l_max)
+    else:
+        calculator = sphericart.SolidHarmonics(l_max=l_max)
+    sph = jitted_sph(xyz=xyz, l_max=l_max)
     sph_ref = calculator.compute(np.asarray(xyz))
     np.testing.assert_allclose(sph, sph_ref, rtol=2e-5, atol=1e-6)
 
@@ -39,11 +41,13 @@ def test_jit(xyz, l_max, normalized):
 @pytest.mark.parametrize("normalized", [True, False])
 @pytest.mark.parametrize("l_max", [4, 7, 10])
 def test_vmap(xyz, l_max, normalized):
-    vmapped_sph = jax.vmap(sphericart.jax.spherical_harmonics, in_axes=(0, None, None))
-    calculator = sphericart.SphericalHarmonics(
-        l_max=l_max, normalized=normalized
-    )
-    sph = vmapped_sph(xyz, l_max, normalized)
+    function = sphericart.jax.spherical_harmonics if normalized else sphericart.jax.solid_harmonics
+    vmapped_sph = jax.vmap(function, in_axes=(0, None))
+    if normalized:
+        calculator = sphericart.SphericalHarmonics(l_max=l_max)
+    else:
+        calculator = sphericart.SolidHarmonics(l_max=l_max)
+    sph = vmapped_sph(xyz, l_max)
     sph_ref = calculator.compute(np.asarray(xyz))
     np.testing.assert_allclose(sph, sph_ref, rtol=2e-5, atol=1e-6)
 
@@ -51,38 +55,42 @@ def test_vmap(xyz, l_max, normalized):
 @pytest.mark.parametrize("normalized", [True, False])
 @pytest.mark.parametrize("l_max", [4, 7, 10])
 def test_jit_jacfwd(xyz, l_max, normalized):
+    function = sphericart.jax.spherical_harmonics if normalized else sphericart.jax.solid_harmonics
     transformed_sph = jax.jit(
-        jax.jacfwd(sphericart.jax.spherical_harmonics), static_argnums=(1, 2)
+        jax.jacfwd(function), static_argnums=(1,)
     )
-    transformed_sph(xyz, l_max, normalized)
+    transformed_sph(xyz, l_max)
 
 
 @pytest.mark.parametrize("normalized", [True, False])
 @pytest.mark.parametrize("l_max", [4, 7, 10])
 def test_hessian_jit(xyz, l_max, normalized):
+    function = sphericart.jax.spherical_harmonics if normalized else sphericart.jax.solid_harmonics
     transformed_sph = jax.hessian(
-        jax.jit(sphericart.jax.spherical_harmonics, static_argnums=(1, 2))
+        jax.jit(function, static_argnums=(1,))
     )
-    transformed_sph(xyz, l_max, normalized)
+    transformed_sph(xyz, l_max)
 
 
 @pytest.mark.parametrize("normalized", [True, False])
 @pytest.mark.parametrize("l_max", [4, 7, 10])
 def test_vmap_grad(xyz, l_max, normalized):
-    def single_scalar_output(x, l_max, normalized):
-        return jnp.sum(sphericart.jax.spherical_harmonics(x, l_max, normalized))
+    function = sphericart.jax.spherical_harmonics if normalized else sphericart.jax.solid_harmonics
+    def single_scalar_output(x, l_max):
+        return jnp.sum(function(x, l_max))
 
     single_grad = jax.grad(single_scalar_output)
-    sh_grad = jax.vmap(single_grad, in_axes=(0, None, None), out_axes=0)
-    sh_grad(xyz, l_max, normalized)
+    sh_grad = jax.vmap(single_grad, in_axes=(0, None), out_axes=0)
+    sh_grad(xyz, l_max)
 
 
 @pytest.mark.parametrize("normalized", [True, False])
 @pytest.mark.parametrize("l_max", [4, 7, 10])
 def test_vmap_hessian(xyz, l_max, normalized):
-    def single_scalar_output(x, l_max, normalized):
-        return jnp.sum(sphericart.jax.spherical_harmonics(x, l_max, normalized))
+    function = sphericart.jax.spherical_harmonics if normalized else sphericart.jax.solid_harmonics
+    def single_scalar_output(x, l_max):
+        return jnp.sum(function(x, l_max))
 
     single_hessian = jax.hessian(single_scalar_output)
-    sh_hessian = jax.vmap(single_hessian, in_axes=(0, None, None), out_axes=0)
-    sh_hessian(xyz, l_max, normalized)
+    sh_hessian = jax.vmap(single_hessian, in_axes=(0, None), out_axes=0)
+    sh_hessian(xyz, l_max)

--- a/sphericart-jax/src/sphericart_jax_cpu.cpp
+++ b/sphericart-jax/src/sphericart_jax_cpu.cpp
@@ -17,52 +17,46 @@ namespace {
 
 // CPU section
 
-template <typename T>
-using CacheMapCPU =
-    std::map<std::tuple<size_t, bool>, std::unique_ptr<sphericart::SphericalHarmonics<T>>>;
+template <template <typename> class C, typename T>
+using CacheMapCPU = std::map<size_t, std::unique_ptr<C<T>>>;
 
-template <typename T>
-std::unique_ptr<sphericart::SphericalHarmonics<T>>& _get_or_create_sph_cpu(
-    CacheMapCPU<T>& sph_cache, std::mutex& cache_mutex, size_t l_max, bool normalized
+template <template <typename> class C, typename T>
+std::unique_ptr<C<T>>& _get_or_create_sph_cpu(
+    CacheMapCPU<C, T>& sph_cache, std::mutex& cache_mutex, size_t l_max
 ) {
     // Check if instance exists in cache, if not create and store it
     std::lock_guard<std::mutex> lock(cache_mutex);
-    auto key = std::make_tuple(l_max, normalized);
-    auto it = sph_cache.find(key);
+    auto it = sph_cache.find(l_max);
     if (it == sph_cache.end()) {
-        it =
-            sph_cache
-                .insert({key, std::make_unique<sphericart::SphericalHarmonics<T>>(l_max, normalized)})
-                .first;
+        it = sph_cache.insert({l_max, std::make_unique<C<T>>(l_max)}).first;
     }
     return it->second;
 }
 
-template <typename T> void cpu_sph(void* out, const void** in) {
+template <template <typename> class C, typename T> void cpu_sph(void* out, const void** in) {
     // Parse the inputs
     const T* xyz = reinterpret_cast<const T*>(in[0]);
     const size_t l_max = *reinterpret_cast<const int*>(in[1]);
-    const bool normalized = *reinterpret_cast<const bool*>(in[2]);
-    const size_t n_samples = *reinterpret_cast<const int*>(in[3]);
+    const size_t n_samples = *reinterpret_cast<const int*>(in[2]);
     size_t xyz_length{n_samples * 3};
     size_t sph_len{(l_max + 1) * (l_max + 1) * n_samples};
     // The output is stored as a single pointer since there is only one output
     T* sph = reinterpret_cast<T*>(out);
 
     // Static map to cache instances based on parameters
-    static CacheMapCPU<T> sph_cache;
+    static CacheMapCPU<C, T> sph_cache;
     static std::mutex cache_mutex;
 
-    auto& calculator = _get_or_create_sph_cpu(sph_cache, cache_mutex, l_max, normalized);
+    auto& calculator = _get_or_create_sph_cpu(sph_cache, cache_mutex, l_max);
     calculator->compute_array(xyz, xyz_length, sph, sph_len);
 }
 
-template <typename T> void cpu_sph_with_gradients(void* out_tuple, const void** in) {
+template <template <typename> class C, typename T>
+void cpu_sph_with_gradients(void* out_tuple, const void** in) {
     // Parse the inputs
     const T* xyz = reinterpret_cast<const T*>(in[0]);
     const size_t l_max = *reinterpret_cast<const int*>(in[1]);
-    const bool normalized = *reinterpret_cast<const bool*>(in[2]);
-    const size_t n_samples = *reinterpret_cast<const int*>(in[3]);
+    const size_t n_samples = *reinterpret_cast<const int*>(in[2]);
     size_t xyz_length{n_samples * 3};
     size_t sph_len{(l_max + 1) * (l_max + 1) * n_samples};
     size_t dsph_len{sph_len * 3};
@@ -72,19 +66,19 @@ template <typename T> void cpu_sph_with_gradients(void* out_tuple, const void** 
     T* dsph = reinterpret_cast<T*>(out[1]);
 
     // Static map to cache instances based on parameters
-    static CacheMapCPU<T> sph_cache;
+    static CacheMapCPU<C, T> sph_cache;
     static std::mutex cache_mutex;
 
-    auto& calculator = _get_or_create_sph_cpu(sph_cache, cache_mutex, l_max, normalized);
+    auto& calculator = _get_or_create_sph_cpu(sph_cache, cache_mutex, l_max);
     calculator->compute_array_with_gradients(xyz, xyz_length, sph, sph_len, dsph, dsph_len);
 }
 
-template <typename T> void cpu_sph_with_hessians(void* out_tuple, const void** in) {
+template <template <typename> class C, typename T>
+void cpu_sph_with_hessians(void* out_tuple, const void** in) {
     // Parse the inputs
     const T* xyz = reinterpret_cast<const T*>(in[0]);
     const size_t l_max = *reinterpret_cast<const int*>(in[1]);
-    const bool normalized = *reinterpret_cast<const bool*>(in[2]);
-    const size_t n_samples = *reinterpret_cast<const int*>(in[3]);
+    const size_t n_samples = *reinterpret_cast<const int*>(in[2]);
     size_t xyz_length{n_samples * 3};
     size_t sph_len{(l_max + 1) * (l_max + 1) * n_samples};
     size_t dsph_len{sph_len * 3};
@@ -96,10 +90,10 @@ template <typename T> void cpu_sph_with_hessians(void* out_tuple, const void** i
     T* ddsph = reinterpret_cast<T*>(out[2]);
 
     // Static map to cache instances based on parameters
-    static CacheMapCPU<T> sph_cache;
+    static CacheMapCPU<C, T> sph_cache;
     static std::mutex cache_mutex;
 
-    auto& calculator = _get_or_create_sph_cpu(sph_cache, cache_mutex, l_max, normalized);
+    auto& calculator = _get_or_create_sph_cpu(sph_cache, cache_mutex, l_max);
     calculator->compute_array_with_hessians(
         xyz, xyz_length, sph, sph_len, dsph, dsph_len, ddsph, ddsph_len
     );
@@ -109,12 +103,26 @@ template <typename T> void cpu_sph_with_hessians(void* out_tuple, const void** i
 
 pybind11::dict Registrations() {
     pybind11::dict dict;
-    dict["cpu_sph_f32"] = EncapsulateFunction(cpu_sph<float>);
-    dict["cpu_sph_f64"] = EncapsulateFunction(cpu_sph<double>);
-    dict["cpu_dsph_f32"] = EncapsulateFunction(cpu_sph_with_gradients<float>);
-    dict["cpu_dsph_f64"] = EncapsulateFunction(cpu_sph_with_gradients<double>);
-    dict["cpu_ddsph_f32"] = EncapsulateFunction(cpu_sph_with_hessians<float>);
-    dict["cpu_ddsph_f64"] = EncapsulateFunction(cpu_sph_with_hessians<double>);
+    dict["cpu_spherical_f32"] = EncapsulateFunction(cpu_sph<sphericart::SphericalHarmonics, float>);
+    dict["cpu_spherical_f64"] = EncapsulateFunction(cpu_sph<sphericart::SphericalHarmonics, double>);
+    dict["cpu_dspherical_f32"] =
+        EncapsulateFunction(cpu_sph_with_gradients<sphericart::SphericalHarmonics, float>);
+    dict["cpu_dspherical_f64"] =
+        EncapsulateFunction(cpu_sph_with_gradients<sphericart::SphericalHarmonics, double>);
+    dict["cpu_ddspherical_f32"] =
+        EncapsulateFunction(cpu_sph_with_hessians<sphericart::SphericalHarmonics, float>);
+    dict["cpu_ddspherical_f64"] =
+        EncapsulateFunction(cpu_sph_with_hessians<sphericart::SphericalHarmonics, double>);
+    dict["cpu_solid_f32"] = EncapsulateFunction(cpu_sph<sphericart::SolidHarmonics, float>);
+    dict["cpu_solid_f64"] = EncapsulateFunction(cpu_sph<sphericart::SolidHarmonics, double>);
+    dict["cpu_dsolid_f32"] =
+        EncapsulateFunction(cpu_sph_with_gradients<sphericart::SolidHarmonics, float>);
+    dict["cpu_dsolid_f64"] =
+        EncapsulateFunction(cpu_sph_with_gradients<sphericart::SolidHarmonics, double>);
+    dict["cpu_ddsolid_f32"] =
+        EncapsulateFunction(cpu_sph_with_hessians<sphericart::SolidHarmonics, float>);
+    dict["cpu_ddsolid_f64"] =
+        EncapsulateFunction(cpu_sph_with_hessians<sphericart::SolidHarmonics, double>);
     return dict;
 }
 

--- a/sphericart-jax/src/sphericart_jax_cuda.cpp
+++ b/sphericart-jax/src/sphericart_jax_cuda.cpp
@@ -2,6 +2,8 @@
 // devices. It is exposed as a standard pybind11 module defining "capsule"
 // objects containing our methods. For simplicity, we export a separate capsule
 // for each supported dtype.
+// This file is separated from `sphericart_jax_cuda.cu` because pybind11 does
+// not accept cuda files.
 
 #include <cstdlib>
 #include <map>
@@ -20,19 +22,25 @@ namespace {
 
 pybind11::dict Registrations() {
     pybind11::dict dict;
-    dict["cuda_sph_f32"] = EncapsulateFunction(apply_cuda_sph_f32);
-    dict["cuda_sph_f64"] = EncapsulateFunction(apply_cuda_sph_f64);
-    dict["cuda_dsph_f32"] = EncapsulateFunction(apply_cuda_sph_with_gradients_f32);
-    dict["cuda_dsph_f64"] = EncapsulateFunction(apply_cuda_sph_with_gradients_f64);
-    dict["cuda_ddsph_f32"] = EncapsulateFunction(apply_cuda_sph_with_hessians_f32);
-    dict["cuda_ddsph_f64"] = EncapsulateFunction(apply_cuda_sph_with_hessians_f64);
+    dict["cuda_spherical_f32"] = EncapsulateFunction(cuda_spherical_f32);
+    dict["cuda_spherical_f64"] = EncapsulateFunction(cuda_spherical_f64);
+    dict["cuda_dspherical_f32"] = EncapsulateFunction(cuda_dspherical_f32);
+    dict["cuda_dspherical_f64"] = EncapsulateFunction(cuda_dspherical_f64);
+    dict["cuda_ddspherical_f32"] = EncapsulateFunction(cuda_ddspherical_f32);
+    dict["cuda_ddspherical_f64"] = EncapsulateFunction(cuda_ddspherical_f64);
+    dict["cuda_solid_f32"] = EncapsulateFunction(cuda_solid_f32);
+    dict["cuda_solid_f64"] = EncapsulateFunction(cuda_solid_f64);
+    dict["cuda_dsolid_f32"] = EncapsulateFunction(cuda_dsolid_f32);
+    dict["cuda_dsolid_f64"] = EncapsulateFunction(cuda_dsolid_f64);
+    dict["cuda_ddsolid_f32"] = EncapsulateFunction(cuda_ddsolid_f32);
+    dict["cuda_ddsolid_f64"] = EncapsulateFunction(cuda_ddsolid_f64);
     return dict;
 }
 
 PYBIND11_MODULE(sphericart_jax_cuda, m) {
     m.def("registrations", &Registrations);
-    m.def("build_sph_descriptor", [](std::int64_t n_samples, std::int64_t lmax, bool normalize) {
-        return PackDescriptor(SphDescriptor{n_samples, lmax, normalize});
+    m.def("build_sph_descriptor", [](std::int64_t n_samples, std::int64_t lmax) {
+        return PackDescriptor(SphDescriptor{n_samples, lmax});
     });
 }
 

--- a/sphericart-jax/src/sphericart_jax_cuda.cu
+++ b/sphericart-jax/src/sphericart_jax_cuda.cu
@@ -1,74 +1,61 @@
-// This file implements the CUDA interface between JAX and the CUDA C++
-// implementation of sphericart.
+// This file defines the Python interface to the XLA custom calls on CUDA
+// devices. It is exposed as a standard pybind11 module defining "capsule"
+// objects containing our methods. For simplicity, we export a separate capsule
+// for each supported dtype.
 
 #include <cstdlib>
 #include <map>
 #include <mutex>
 #include <tuple>
 
+#include <cuda_runtime.h>
+#include <cuda_runtime_api.h>
+
+#include "sphericart_cuda.hpp"
 #include "sphericart/pybind11_kernel_helpers.hpp"
 #include "sphericart/sphericart_jax_cuda.hpp"
 
-#include "sphericart_cuda.hpp"
-
 namespace sphericart_jax {
-
 namespace cuda {
 
-template <typename T>
-using CacheMapCUDA =
-    std::map<std::tuple<size_t, bool>, std::unique_ptr<sphericart::cuda::SphericalHarmonics<T>>>;
+template <template <typename> class C, typename T>
+using CacheMapCUDA = std::map<size_t, std::unique_ptr<C<T>>>;
 
-template <typename T>
-std::unique_ptr<sphericart::cuda::SphericalHarmonics<T>>& _get_or_create_sph_cuda(
-    CacheMapCUDA<T>& sph_cache, std::mutex& cache_mutex, size_t l_max, bool normalized
+template <template <typename> class C, typename T>
+std::unique_ptr<C<T>>& _get_or_create_sph_cuda(
+    CacheMapCUDA<C, T>& sph_cache, std::mutex& cache_mutex, size_t l_max
 ) {
     // Check if instance exists in cache, if not create and store it
     std::lock_guard<std::mutex> lock(cache_mutex);
-    auto key = std::make_tuple(l_max, normalized);
-    auto it = sph_cache.find(key);
+    auto it = sph_cache.find(l_max);
     if (it == sph_cache.end()) {
-        it = sph_cache
-                 .insert(
-                     {key,
-                      std::make_unique<sphericart::cuda::SphericalHarmonics<T>>(l_max, normalized)}
-                 )
-                 .first;
+        it = sph_cache.insert({l_max, std::make_unique<C<T>>(l_max)}).first;
     }
     return it->second;
 }
 
-template <typename T>
+template <template <typename> class C, typename T>
 inline void cuda_sph(cudaStream_t stream, void** in, const char* opaque, std::size_t opaque_len) {
     // Parse the inputs
     const T* xyz = reinterpret_cast<const T*>(in[0]);
     T* sph = reinterpret_cast<T*>(in[1]);
 
     // Static map to cache instances based on parameters
-    static CacheMapCUDA<T> sph_cache;
+    static CacheMapCUDA<C, T> sph_cache;
     static std::mutex cache_mutex;
 
     const SphDescriptor& d = *UnpackDescriptor<SphDescriptor>(opaque, opaque_len);
     const std::int64_t n_samples = d.n_samples;
     const std::int64_t lmax = d.lmax;
-    const bool normalize = d.normalize;
 
-    auto& calculator = _get_or_create_sph_cuda(sph_cache, cache_mutex, lmax, normalize);
+    auto& calculator = _get_or_create_sph_cuda(sph_cache, cache_mutex, lmax);
 
     calculator->compute(
         xyz, n_samples, false, false, sph, nullptr, nullptr, reinterpret_cast<void*>(stream)
     );
 }
 
-void apply_cuda_sph_f32(cudaStream_t stream, void** in, const char* opaque, std::size_t opaque_len) {
-    cuda_sph<float>(stream, in, opaque, opaque_len);
-}
-
-void apply_cuda_sph_f64(cudaStream_t stream, void** in, const char* opaque, std::size_t opaque_len) {
-    cuda_sph<double>(stream, in, opaque, opaque_len);
-}
-
-template <typename T>
+template <template <typename> class C, typename T>
 inline void cuda_sph_with_gradients(
     cudaStream_t stream, void** in, const char* opaque, std::size_t opaque_len
 ) {
@@ -78,33 +65,20 @@ inline void cuda_sph_with_gradients(
     T* dsph = reinterpret_cast<T*>(in[2]);
 
     // Static map to cache instances based on parameters
-    static CacheMapCUDA<T> sph_cache;
+    static CacheMapCUDA<C, T> sph_cache;
     static std::mutex cache_mutex;
 
     const SphDescriptor& d = *UnpackDescriptor<SphDescriptor>(opaque, opaque_len);
     const std::int64_t n_samples = d.n_samples;
     const std::int64_t lmax = d.lmax;
-    const bool normalize = d.normalize;
 
-    auto& calculator = _get_or_create_sph_cuda(sph_cache, cache_mutex, lmax, normalize);
+    auto& calculator = _get_or_create_sph_cuda(sph_cache, cache_mutex, lmax);
     calculator->compute(
         xyz, n_samples, true, false, sph, dsph, nullptr, reinterpret_cast<void*>(stream)
     );
 }
 
-void apply_cuda_sph_with_gradients_f32(
-    cudaStream_t stream, void** in, const char* opaque, std::size_t opaque_len
-) {
-    cuda_sph_with_gradients<float>(stream, in, opaque, opaque_len);
-}
-
-void apply_cuda_sph_with_gradients_f64(
-    cudaStream_t stream, void** in, const char* opaque, std::size_t opaque_len
-) {
-    cuda_sph_with_gradients<double>(stream, in, opaque, opaque_len);
-}
-
-template <typename T>
+template <template <typename> class C, typename T>
 inline void cuda_sph_with_hessians(
     cudaStream_t stream, void** in, const char* opaque, std::size_t opaque_len
 ) {
@@ -115,30 +89,74 @@ inline void cuda_sph_with_hessians(
     T* ddsph = reinterpret_cast<T*>(in[3]);
 
     // Static map to cache instances based on parameters
-    static CacheMapCUDA<T> sph_cache;
+    static CacheMapCUDA<C, T> sph_cache;
     static std::mutex cache_mutex;
 
     const SphDescriptor& d = *UnpackDescriptor<SphDescriptor>(opaque, opaque_len);
     const std::int64_t n_samples = d.n_samples;
     const std::int64_t lmax = d.lmax;
-    const bool normalize = d.normalize;
 
-    auto& calculator = _get_or_create_sph_cuda(sph_cache, cache_mutex, lmax, normalize);
+    auto& calculator = _get_or_create_sph_cuda(sph_cache, cache_mutex, lmax);
     calculator->compute(
         xyz, n_samples, true, true, sph, dsph, ddsph, reinterpret_cast<void*>(stream)
     );
 }
 
-void apply_cuda_sph_with_hessians_f32(
-    cudaStream_t stream, void** in, const char* opaque, std::size_t opaque_len
-) {
-    cuda_sph_with_hessians<float>(stream, in, opaque, opaque_len);
+void cuda_spherical_f32(cudaStream_t stream, void** in, const char* opaque, std::size_t opaque_len) {
+    cuda_sph<sphericart::cuda::SphericalHarmonics, float>(stream, in, opaque, opaque_len);
 }
 
-void apply_cuda_sph_with_hessians_f64(
-    cudaStream_t stream, void** in, const char* opaque, std::size_t opaque_len
-) {
-    cuda_sph_with_hessians<double>(stream, in, opaque, opaque_len);
+void cuda_spherical_f64(cudaStream_t stream, void** in, const char* opaque, std::size_t opaque_len) {
+    cuda_sph<sphericart::cuda::SphericalHarmonics, double>(stream, in, opaque, opaque_len);
 }
+
+void cuda_dspherical_f32(cudaStream_t stream, void** in, const char* opaque, std::size_t opaque_len) {
+    cuda_sph_with_gradients<sphericart::cuda::SphericalHarmonics, float>(
+        stream, in, opaque, opaque_len
+    );
+}
+
+void cuda_dspherical_f64(cudaStream_t stream, void** in, const char* opaque, std::size_t opaque_len) {
+    cuda_sph_with_gradients<sphericart::cuda::SphericalHarmonics, double>(
+        stream, in, opaque, opaque_len
+    );
+}
+
+void cuda_ddspherical_f32(cudaStream_t stream, void** in, const char* opaque, std::size_t opaque_len) {
+    cuda_sph_with_hessians<sphericart::cuda::SphericalHarmonics, float>(
+        stream, in, opaque, opaque_len
+    );
+}
+
+void cuda_ddspherical_f64(cudaStream_t stream, void** in, const char* opaque, std::size_t opaque_len) {
+    cuda_sph_with_hessians<sphericart::cuda::SphericalHarmonics, double>(
+        stream, in, opaque, opaque_len
+    );
+}
+
+void cuda_solid_f32(cudaStream_t stream, void** in, const char* opaque, std::size_t opaque_len) {
+    cuda_sph<sphericart::cuda::SolidHarmonics, float>(stream, in, opaque, opaque_len);
+}
+
+void cuda_solid_f64(cudaStream_t stream, void** in, const char* opaque, std::size_t opaque_len) {
+    cuda_sph<sphericart::cuda::SolidHarmonics, double>(stream, in, opaque, opaque_len);
+}
+
+void cuda_dsolid_f32(cudaStream_t stream, void** in, const char* opaque, std::size_t opaque_len) {
+    cuda_sph_with_gradients<sphericart::cuda::SolidHarmonics, float>(stream, in, opaque, opaque_len);
+}
+
+void cuda_dsolid_f64(cudaStream_t stream, void** in, const char* opaque, std::size_t opaque_len) {
+    cuda_sph_with_gradients<sphericart::cuda::SolidHarmonics, double>(stream, in, opaque, opaque_len);
+}
+
+void cuda_ddsolid_f32(cudaStream_t stream, void** in, const char* opaque, std::size_t opaque_len) {
+    cuda_sph_with_hessians<sphericart::cuda::SolidHarmonics, float>(stream, in, opaque, opaque_len);
+}
+
+void cuda_ddsolid_f64(cudaStream_t stream, void** in, const char* opaque, std::size_t opaque_len) {
+    cuda_sph_with_hessians<sphericart::cuda::SolidHarmonics, double>(stream, in, opaque, opaque_len);
+}
+
 } // namespace cuda
 } // namespace sphericart_jax

--- a/sphericart-torch/include/sphericart/autograd.hpp
+++ b/sphericart-torch/include/sphericart/autograd.hpp
@@ -10,11 +10,12 @@ namespace sphericart_torch {
 
 class SphericalHarmonics;
 
-class SphericalHarmonicsAutograd : public torch::autograd::Function<SphericalHarmonicsAutograd> {
+class SphericartAutograd : public torch::autograd::Function<SphericartAutograd> {
   public:
+    template <typename C>
     static torch::autograd::variable_list forward(
         torch::autograd::AutogradContext* ctx,
-        SphericalHarmonics& calculator,
+        C& calculator,
         torch::Tensor xyz,
         bool do_gradients,
         bool do_hessians
@@ -25,8 +26,7 @@ class SphericalHarmonicsAutograd : public torch::autograd::Function<SphericalHar
     );
 };
 
-class SphericalHarmonicsAutogradBackward
-    : public torch::autograd::Function<SphericalHarmonicsAutogradBackward> {
+class SphericartAutogradBackward : public torch::autograd::Function<SphericartAutogradBackward> {
   public:
     static torch::Tensor forward(
         torch::autograd::AutogradContext* ctx,

--- a/sphericart-torch/include/sphericart/autograd.hpp
+++ b/sphericart-torch/include/sphericart/autograd.hpp
@@ -1,19 +1,15 @@
 #ifndef SPHERICART_TORCH_AUTOGRAD_HPP
 #define SPHERICART_TORCH_AUTOGRAD_HPP
 
-#include <ATen/Tensor.h>
-#include <torch/autograd.h>
-#include <torch/data.h>
 #include <vector>
+#include <torch/torch.h>
 
 namespace sphericart_torch {
-
-class SphericalHarmonics;
 
 class SphericartAutograd : public torch::autograd::Function<SphericartAutograd> {
   public:
     template <typename C>
-    static torch::autograd::variable_list forward(
+    static std::vector<torch::Tensor> forward(
         torch::autograd::AutogradContext* ctx,
         C& calculator,
         torch::Tensor xyz,
@@ -21,8 +17,8 @@ class SphericartAutograd : public torch::autograd::Function<SphericartAutograd> 
         bool do_hessians
     );
 
-    static torch::autograd::variable_list backward(
-        torch::autograd::AutogradContext* ctx, torch::autograd::variable_list grad_outputs
+    static std::vector<torch::Tensor> backward(
+        torch::autograd::AutogradContext* ctx, std::vector<torch::Tensor> grad_outputs
     );
 };
 
@@ -35,8 +31,8 @@ class SphericartAutogradBackward : public torch::autograd::Function<SphericartAu
         std::vector<torch::Tensor> saved_variables
     );
 
-    static torch::autograd::variable_list backward(
-        torch::autograd::AutogradContext* ctx, torch::autograd::variable_list grad_2_outputs
+    static std::vector<torch::Tensor> backward(
+        torch::autograd::AutogradContext* ctx, std::vector<torch::Tensor> grad_2_outputs
     );
 };
 

--- a/sphericart-torch/include/sphericart/torch.hpp
+++ b/sphericart-torch/include/sphericart/torch.hpp
@@ -10,14 +10,12 @@
 
 namespace sphericart_torch {
 
-class SphericalHarmonicsAutograd;
-class SphericalHarmonicsAutogradBackward;
+class SphericartAutograd;
+class SphericartAutogradBackward;
 
 class SphericalHarmonics : public torch::CustomClassHolder {
   public:
-    SphericalHarmonics(
-        int64_t l_max, bool normalized = false, bool backward_second_derivatives = false
-    );
+    SphericalHarmonics(int64_t l_max, bool backward_second_derivatives = false);
 
     // Actual calculation, with autograd support
     torch::Tensor compute(torch::Tensor xyz);
@@ -26,11 +24,12 @@ class SphericalHarmonics : public torch::CustomClassHolder {
 
     int64_t get_l_max() const { return this->l_max_; }
     bool get_backward_second_derivative_flag() const { return this->backward_second_derivatives_; }
-    bool get_normalized_flag() const { return this->normalized_; }
     int64_t get_omp_num_threads() const { return this->omp_num_threads_; }
 
+    friend class SolidHarmonics;
+
   private:
-    friend class SphericalHarmonicsAutograd;
+    friend class SphericartAutograd;
 
     // Raw calculation, without autograd support, running on CPU
     std::vector<torch::Tensor> compute_raw_cpu(torch::Tensor xyz, bool do_gradients, bool do_hessians);
@@ -38,7 +37,6 @@ class SphericalHarmonics : public torch::CustomClassHolder {
     int64_t omp_num_threads_;
     int64_t l_max_;
     bool backward_second_derivatives_;
-    bool normalized_;
 
     // CPU implementation
     sphericart::SphericalHarmonics<double> calculator_double_;
@@ -47,6 +45,25 @@ class SphericalHarmonics : public torch::CustomClassHolder {
     // CUDA implementation
     std::unique_ptr<sphericart::cuda::SphericalHarmonics<double>> calculator_cuda_double_ptr;
     std::unique_ptr<sphericart::cuda::SphericalHarmonics<float>> calculator_cuda_float_ptr;
+};
+
+class SolidHarmonics : public SphericalHarmonics {
+  public:
+    SolidHarmonics(int64_t l_max, bool backward_second_derivatives = false);
+
+  private:
+    friend class SphericartAutograd;
+
+    int64_t l_max_;
+    bool backward_second_derivatives_;
+
+    // CPU implementation
+    sphericart::SolidHarmonics<double> calculator_double_;
+    sphericart::SolidHarmonics<float> calculator_float_;
+
+    // CUDA implementation
+    std::unique_ptr<sphericart::cuda::SolidHarmonics<double>> calculator_cuda_double_ptr;
+    std::unique_ptr<sphericart::cuda::SolidHarmonics<float>> calculator_cuda_float_ptr;
 };
 
 } // namespace sphericart_torch

--- a/sphericart-torch/include/sphericart/torch_cuda_wrapper.hpp
+++ b/sphericart-torch/include/sphericart/torch_cuda_wrapper.hpp
@@ -1,14 +1,13 @@
 #ifndef SPHERICART_TORCH_TORCH_CUDA_WRAPPER_HPP
 #define SPHERICART_TORCH_TORCH_CUDA_WRAPPER_HPP
 
-#include <ATen/Tensor.h>
-#include <torch/torch.h>
 #include <vector>
+#include <torch/torch.h>
 
 namespace sphericart_torch {
 
-at::Tensor spherical_harmonics_backward_cuda(
-    at::Tensor xyz, at::Tensor dsph, at::Tensor sph_grad, void* cuda_stream
+torch::Tensor spherical_harmonics_backward_cuda(
+    torch::Tensor xyz, torch::Tensor dsph, torch::Tensor sph_grad, void* cuda_stream
 );
 
 } // namespace sphericart_torch

--- a/sphericart-torch/python/sphericart/torch/__init__.py
+++ b/sphericart-torch/python/sphericart/torch/__init__.py
@@ -85,19 +85,19 @@ class SphericalHarmonics:
     and/or Hessians. For example:
 
     >>> import torch
-    >>> import sphericart.torch as sct
-    >>> sh = sct.SphericalHarmonics(l_max=8, normalized=False)
+    >>> import sphericart.torch
+    >>> sh = sphericart.torch.SphericalHarmonics(l_max=8, normalized=False)
     >>> xyz = torch.rand(size=(10,3))
     >>> sh_values, sh_grads = sh.compute_with_gradients(xyz)
     >>> sh_grads.shape
     torch.Size([10, 3, 81])
 
-    Alternatively, if `compute()` is called, the outputs support
-    single and double backpropagation.
+    Alternatively, if `compute()` is used, or if the class is called directly,
+    the outputs support single and double backpropagation.
 
     >>> xyz = xyz.detach().clone().requires_grad_()
-    >>> sh = sct.SphericalHarmonics(l_max=8, normalized=False)
-    >>> sh_values = sh.compute(xyz)
+    >>> sh = sphericart.torch.SphericalHarmonics(l_max=8, normalized=False)
+    >>> sh_values = sh(xyz)  # or sh.compute(xyz)
     >>> sh_values.sum().backward()
     >>> torch.allclose(xyz.grad, sh_grads.sum(axis=-1))
     True
@@ -168,6 +168,12 @@ class SphericalHarmonics:
             1), (2, -2), (2, -1), (2, 0), (2, 1), (2, 2)``, in this order.
         """
 
+        pass
+
+    def __call__(self, xyz: Tensor) -> Tensor:
+        """
+        Equivalent to ``compute()``.
+        """
         pass
 
     def compute_with_gradients(self, xyz: Tensor) -> Tuple[Tensor, Tensor]:

--- a/sphericart-torch/python/tests/test_autograd.py
+++ b/sphericart-torch/python/tests/test_autograd.py
@@ -14,8 +14,8 @@ def xyz():
 
 
 def test_autograd_cartesian(xyz):
-    calculator = sphericart.torch.SphericalHarmonics(
-        l_max=4, normalized=False, backward_second_derivatives=True
+    calculator = sphericart.torch.SolidHarmonics(
+        l_max=4, backward_second_derivatives=True
     )
 
     def compute(xyz):
@@ -33,8 +33,8 @@ def test_autograd_cartesian(xyz):
 
 
 def test_autograd_normalized(xyz):
-    calculator = sphericart.torch.SphericalHarmonics(
-        l_max=4, normalized=True, backward_second_derivatives=True
+    calculator = sphericart.torch.SolidHarmonics(
+        l_max=4, backward_second_derivatives=True
     )
 
     def compute(xyz):
@@ -53,8 +53,8 @@ def test_autograd_normalized(xyz):
 
 def test_autograd_hessian(xyz):
     # Initialize a calculator with l_max = 1
-    calculator = sphericart.torch.SphericalHarmonics(
-        l_max=1, normalized=False, backward_second_derivatives=True
+    calculator = sphericart.torch.SolidHarmonics(
+        l_max=1, backward_second_derivatives=True
     )
 
     # Fill a single xyz point with arbitrary numbers

--- a/sphericart-torch/python/tests/test_cuda.py
+++ b/sphericart-torch/python/tests/test_cuda.py
@@ -16,7 +16,7 @@ def test_cpu_vs_cuda(xyz):
     if torch.cuda.is_available():
         xyz_cuda = xyz.to("cuda")
 
-        calculator = sphericart.torch.SphericalHarmonics(l_max=20, normalized=False)
+        calculator = sphericart.torch.SolidHarmonics(l_max=20)
         sph, grad_sph = calculator.compute_with_gradients(xyz)
         sph_cuda, grad_sph_cuda = calculator.compute_with_gradients(xyz_cuda)
 
@@ -27,7 +27,7 @@ def test_cpu_vs_cuda(xyz):
         assert torch.allclose(sph, sph_cuda.to("cpu"))
         assert torch.allclose(grad_sph, grad_sph_cuda.to("cpu"))
 
-        calculator = sphericart.torch.SphericalHarmonics(l_max=20, normalized=True)
+        calculator = sphericart.torch.SphericalHarmonics(l_max=20)
         sph, grad_sph = calculator.compute_with_gradients(xyz)
         sph_cuda, grad_sph_cuda = calculator.compute_with_gradients(xyz_cuda)
 

--- a/sphericart-torch/python/tests/test_cuda_stream.py
+++ b/sphericart-torch/python/tests/test_cuda_stream.py
@@ -14,7 +14,7 @@ def xyz():
 
 def test_cpu_vs_cuda(xyz):
     if torch.cuda.is_available():
-        calculator = sphericart.torch.SphericalHarmonics(l_max=20, normalized=False)
+        calculator = sphericart.torch.SolidHarmonics(l_max=20)
 
         s1 = torch.cuda.Stream()
         s2 = torch.cuda.Stream()

--- a/sphericart-torch/python/tests/test_nn.py
+++ b/sphericart-torch/python/tests/test_nn.py
@@ -16,9 +16,7 @@ def test_nn():
     class NN(torch.nn.Module):
         def __init__(self) -> None:
             super().__init__()
-            self.sh_calculator = sphericart.torch.SphericalHarmonics(
-                l_max=1, normalized=True
-            )
+            self.sh_calculator = sphericart.torch.SphericalHarmonics(l_max=1)
             self.linear_layer = torch.nn.Linear(4, 1, bias=False)
 
         def forward(self, positions):
@@ -61,7 +59,6 @@ def test_nn_consistency():
             super().__init__()
             self.sh_calculator = sphericart.torch.SphericalHarmonics(
                 l_max=1,
-                normalized=True,
                 backward_second_derivatives=backward_second_derivatives,
             )
             self.linear_layer = torch.nn.Linear(4, 1, bias=False)

--- a/sphericart-torch/python/tests/test_no_points.py
+++ b/sphericart-torch/python/tests/test_no_points.py
@@ -12,7 +12,10 @@ torch.manual_seed(0)
 def test_error(l_max, normalized):
     xyz = torch.zeros(0, 3, dtype=torch.float64)
 
-    calculator = sphericart.torch.SphericalHarmonics(l_max=l_max, normalized=normalized)
+    if normalized:
+        calculator = sphericart.torch.SphericalHarmonics(l_max=l_max)
+    else:
+        calculator = sphericart.torch.SolidHarmonics(l_max=l_max)
 
     sph = calculator.compute(xyz)
     assert sph.shape == (0, (l_max + 1) ** 2)

--- a/sphericart-torch/python/tests/test_precision.py
+++ b/sphericart-torch/python/tests/test_precision.py
@@ -13,7 +13,7 @@ def xyz():
 
 
 def test_precision(xyz):
-    calculator = sphericart.torch.SphericalHarmonics(l_max=4, normalized=False)
+    calculator = sphericart.torch.SolidHarmonics(l_max=4)
 
     xyz_64 = xyz.clone().to(dtype=torch.float64).detach().requires_grad_(True)
     xyz_32 = xyz.clone().to(dtype=torch.float32).detach().requires_grad_(True)

--- a/sphericart-torch/python/tests/test_script.py
+++ b/sphericart-torch/python/tests/test_script.py
@@ -12,7 +12,10 @@ class SHModule(torch.nn.Module):
     `torch.nn.Module`"""
 
     def __init__(self, l_max, normalized=False):
-        self._sph = sphericart.torch.SphericalHarmonics(l_max, normalized)
+        if normalized:
+            self._sph = sphericart.torch.SphericalHarmonics(l_max)
+        else:
+            self._sph = sphericart.torch.SolidHarmonics(l_max)
         super().__init__()
 
     def forward(self, xyz):

--- a/sphericart-torch/src/autograd.cpp
+++ b/sphericart-torch/src/autograd.cpp
@@ -13,7 +13,6 @@
 #include "sphericart/torch_cuda_wrapper.hpp"
 #include <torch/torch.h>
 
-using namespace std;
 using namespace sphericart_torch;
 
 std::vector<torch::Tensor> SphericalHarmonics::compute_raw_cpu(

--- a/sphericart-torch/src/autograd.cpp
+++ b/sphericart-torch/src/autograd.cpp
@@ -163,9 +163,10 @@ static torch::Tensor backward_cpu(torch::Tensor xyz, torch::Tensor dsph, torch::
     return xyz_grad;
 }
 
-torch::autograd::variable_list SphericalHarmonicsAutograd::forward(
+template <class C>
+torch::autograd::variable_list SphericartAutograd::forward(
     torch::autograd::AutogradContext* ctx,
-    SphericalHarmonics& calculator,
+    C& calculator,
     torch::Tensor xyz,
     bool do_gradients,
     bool do_hessians
@@ -283,7 +284,7 @@ torch::autograd::variable_list SphericalHarmonicsAutograd::forward(
     }
 }
 
-torch::autograd::variable_list SphericalHarmonicsAutograd::backward(
+torch::autograd::variable_list SphericartAutograd::backward(
     torch::autograd::AutogradContext* ctx, torch::autograd::variable_list grad_outputs
 ) {
     if (grad_outputs.size() > 1) {
@@ -299,11 +300,11 @@ torch::autograd::variable_list SphericalHarmonicsAutograd::backward(
     // gradients with respect to it
     auto xyz = saved_variables[0];
     torch::Tensor xyz_grad =
-        SphericalHarmonicsAutogradBackward::apply(grad_outputs[0].contiguous(), xyz, saved_variables);
+        SphericartAutogradBackward::apply(grad_outputs[0].contiguous(), xyz, saved_variables);
     return {torch::Tensor(), xyz_grad, torch::Tensor(), torch::Tensor()};
 }
 
-torch::Tensor SphericalHarmonicsAutogradBackward::forward(
+torch::Tensor SphericartAutogradBackward::forward(
     torch::autograd::AutogradContext* ctx,
     torch::Tensor grad_outputs,
     torch::Tensor xyz,
@@ -336,7 +337,7 @@ torch::Tensor SphericalHarmonicsAutogradBackward::forward(
     return xyz_grad;
 }
 
-torch::autograd::variable_list SphericalHarmonicsAutogradBackward::backward(
+torch::autograd::variable_list SphericartAutogradBackward::backward(
     torch::autograd::AutogradContext* ctx, torch::autograd::variable_list grad_2_outputs
 ) {
     auto saved_variables = ctx->get_saved_variables();
@@ -389,3 +390,19 @@ torch::autograd::variable_list SphericalHarmonicsAutogradBackward::backward(
 
     return {gradgrad_wrt_grad_out, gradgrad_wrt_xyz, torch::Tensor()};
 }
+
+// Explicit instantiation of SphericartAutograd::forward
+template torch::autograd::variable_list SphericartAutograd::forward<SphericalHarmonics>(
+    torch::autograd::AutogradContext* ctx,
+    SphericalHarmonics& calculator,
+    torch::Tensor xyz,
+    bool do_gradients,
+    bool do_hessians
+);
+template torch::autograd::variable_list SphericartAutograd::forward<SolidHarmonics>(
+    torch::autograd::AutogradContext* ctx,
+    SolidHarmonics& calculator,
+    torch::Tensor xyz,
+    bool do_gradients,
+    bool do_hessians
+);

--- a/sphericart-torch/src/torch.cpp
+++ b/sphericart-torch/src/torch.cpp
@@ -6,41 +6,53 @@
 using namespace torch;
 using namespace sphericart_torch;
 
-SphericalHarmonics::SphericalHarmonics(int64_t l_max, bool normalized, bool backward_second_derivatives)
-    : l_max_(l_max), normalized_(normalized),
-      backward_second_derivatives_(backward_second_derivatives),
-      calculator_double_(l_max_, normalized_), calculator_float_(l_max_, normalized_) {
+SphericalHarmonics::SphericalHarmonics(int64_t l_max, bool backward_second_derivatives)
+    : l_max_(l_max), backward_second_derivatives_(backward_second_derivatives),
+      calculator_double_(l_max_), calculator_float_(l_max_) {
     this->omp_num_threads_ = calculator_double_.get_omp_num_threads();
 
     if (torch::cuda::is_available()) {
         this->calculator_cuda_double_ptr =
-            std::make_unique<sphericart::cuda::SphericalHarmonics<double>>(l_max_, normalized_);
+            std::make_unique<sphericart::cuda::SphericalHarmonics<double>>(l_max_);
 
         this->calculator_cuda_float_ptr =
-            std::make_unique<sphericart::cuda::SphericalHarmonics<float>>(l_max_, normalized_);
+            std::make_unique<sphericart::cuda::SphericalHarmonics<float>>(l_max_);
     }
 }
 
 torch::Tensor SphericalHarmonics::compute(torch::Tensor xyz) {
-    return SphericalHarmonicsAutograd::apply(*this, xyz, false, false)[0];
+    return SphericartAutograd::apply(*this, xyz, false, false)[0];
 }
 
 std::vector<torch::Tensor> SphericalHarmonics::compute_with_gradients(torch::Tensor xyz) {
-    return SphericalHarmonicsAutograd::apply(*this, xyz, true, false);
+    return SphericartAutograd::apply(*this, xyz, true, false);
 }
 
 std::vector<torch::Tensor> SphericalHarmonics::compute_with_hessians(torch::Tensor xyz) {
-    return SphericalHarmonicsAutograd::apply(*this, xyz, true, true);
+    return SphericartAutograd::apply(*this, xyz, true, true);
+}
+
+SolidHarmonics::SolidHarmonics(int64_t l_max, bool backward_second_derivatives)
+    : SphericalHarmonics(l_max, backward_second_derivatives), l_max_(l_max),
+      backward_second_derivatives_(backward_second_derivatives), calculator_double_(l_max_),
+      calculator_float_(l_max_) {
+    this->omp_num_threads_ = calculator_double_.get_omp_num_threads();
+
+    if (torch::cuda::is_available()) {
+        this->calculator_cuda_double_ptr =
+            std::make_unique<sphericart::cuda::SolidHarmonics<double>>(l_max_);
+
+        this->calculator_cuda_float_ptr =
+            std::make_unique<sphericart::cuda::SolidHarmonics<float>>(l_max_);
+    }
 }
 
 TORCH_LIBRARY(sphericart_torch, m) {
     m.class_<SphericalHarmonics>("SphericalHarmonics")
         .def(
-            torch::init<int64_t, bool, bool>(),
+            torch::init<int64_t, bool>(),
             "",
-            {torch::arg("l_max"),
-             torch::arg("normalized") = false,
-             torch::arg("backward_second_derivatives") = false}
+            {torch::arg("l_max"), torch::arg("backward_second_derivatives") = false}
         )
         .def("__call__", &SphericalHarmonics::compute, "", {torch::arg("xyz")})
         .def("compute", &SphericalHarmonics::compute, "", {torch::arg("xyz")})
@@ -58,25 +70,43 @@ TORCH_LIBRARY(sphericart_torch, m) {
         )
         .def("omp_num_threads", &SphericalHarmonics::get_omp_num_threads)
         .def("l_max", &SphericalHarmonics::get_l_max)
-        .def("normalized", &SphericalHarmonics::get_normalized_flag)
         .def_pickle(
             // __getstate__
-            [](const c10::intrusive_ptr<SphericalHarmonics>& self
-            ) -> std::tuple<int64_t, bool, bool> {
-                return {
-                    self->get_l_max(),
-                    self->get_normalized_flag(),
-                    self->get_backward_second_derivative_flag()
-                };
+            [](const c10::intrusive_ptr<SphericalHarmonics>& self) -> std::tuple<int64_t, bool> {
+                return {self->get_l_max(), self->get_backward_second_derivative_flag()};
             },
             // __setstate__
-            [](std::tuple<int64_t, bool, bool> state) -> c10::intrusive_ptr<SphericalHarmonics> {
+            [](std::tuple<int64_t, bool> state) -> c10::intrusive_ptr<SphericalHarmonics> {
                 const auto l_max = std::get<0>(state);
-                const auto normalized = std::get<1>(state);
-                const auto backward_second_derivatives = std::get<2>(state);
-                return c10::make_intrusive<SphericalHarmonics>(
-                    l_max, normalized, backward_second_derivatives
-                );
+                const auto backward_second_derivatives = std::get<1>(state);
+                return c10::make_intrusive<SphericalHarmonics>(l_max, backward_second_derivatives);
+            }
+        );
+
+    m.class_<SolidHarmonics>("SolidHarmonics")
+        .def(
+            torch::init<int64_t, bool>(),
+            "",
+            {torch::arg("l_max"), torch::arg("backward_second_derivatives") = false}
+        )
+        .def("__call__", &SolidHarmonics::compute, "", {torch::arg("xyz")})
+        .def("compute", &SolidHarmonics::compute, "", {torch::arg("xyz")})
+        .def(
+            "compute_with_gradients", &SolidHarmonics::compute_with_gradients, "", {torch::arg("xyz")}
+        )
+        .def("compute_with_hessians", &SolidHarmonics::compute_with_hessians, "", {torch::arg("xyz")})
+        .def("omp_num_threads", &SolidHarmonics::get_omp_num_threads)
+        .def("l_max", &SolidHarmonics::get_l_max)
+        .def_pickle(
+            // __getstate__
+            [](const c10::intrusive_ptr<SolidHarmonics>& self) -> std::tuple<int64_t, bool> {
+                return {self->get_l_max(), self->get_backward_second_derivative_flag()};
+            },
+            // __setstate__
+            [](std::tuple<int64_t, bool> state) -> c10::intrusive_ptr<SolidHarmonics> {
+                const auto l_max = std::get<0>(state);
+                const auto backward_second_derivatives = std::get<1>(state);
+                return c10::make_intrusive<SolidHarmonics>(l_max, backward_second_derivatives);
             }
         );
 }

--- a/sphericart-torch/src/torch.cpp
+++ b/sphericart-torch/src/torch.cpp
@@ -5,7 +5,6 @@
 
 using namespace torch;
 using namespace sphericart_torch;
-using namespace std;
 
 SphericalHarmonics::SphericalHarmonics(int64_t l_max, bool normalized, bool backward_second_derivatives)
     : l_max_(l_max), normalized_(normalized),
@@ -43,6 +42,7 @@ TORCH_LIBRARY(sphericart_torch, m) {
              torch::arg("normalized") = false,
              torch::arg("backward_second_derivatives") = false}
         )
+        .def("__call__", &SphericalHarmonics::compute, "", {torch::arg("xyz")})
         .def("compute", &SphericalHarmonics::compute, "", {torch::arg("xyz")})
         .def(
             "compute_with_gradients",

--- a/sphericart/include/sphericart.h
+++ b/sphericart/include/sphericart.h
@@ -13,8 +13,10 @@
 
 #include "sphericart.hpp"
 
-using sphericart_calculator_t = sphericart::SphericalHarmonics<double>;
-using sphericart_calculator_f_t = sphericart::SphericalHarmonics<float>;
+using sphericart_spherical_harmonics_calculator_t = sphericart::SphericalHarmonics<double>;
+using sphericart_spherical_harmonics_calculator_f_t = sphericart::SphericalHarmonics<float>;
+using sphericart_solid_harmonics_calculator_t = sphericart::SolidHarmonics<double>;
+using sphericart_solid_harmonics_calculator_f_t = sphericart::SolidHarmonics<float>;
 
 extern "C" {
 
@@ -23,25 +25,50 @@ extern "C" {
  * Opaque type to hold a spherical harmonics calculator object, that contains
  * pre-computed factors and allocated buffer space for calculations.
  *
- * The `sphericart_calculator_t` performs calculations with `double` data type.
+ * The `sphericart_spherical_harmonics_calculator_t` performs calculations with `double` data type.
  */
-struct sphericart_calculator_t;
+struct sphericart_spherical_harmonics_calculator_t;
 
 /**
- * A type referring to the `sphericart_calculator_t` struct.
+ * A type referring to the `sphericart_spherical_harmonics_calculator_t` struct.
  */
-typedef struct sphericart_calculator_t sphericart_calculator_t;
+typedef struct sphericart_spherical_harmonics_calculator_t sphericart_spherical_harmonics_calculator_t;
 
 /**
- * Similar to `sphericart_calculator_t`, but operating on the `float` data
+ * Similar to `sphericart_spherical_harmonics_calculator_t`, but operating on the `float` data
  * type.
  */
-struct sphericart_calculator_f_t;
+struct sphericart_spherical_harmonics_calculator_f_t;
 
 /**
- * A type referring to the `sphericart_calculator_f_t` struct.
+ * A type referring to the `sphericart_spherical_harmonics_calculator_f_t` struct.
  */
-typedef struct sphericart_calculator_f_t sphericart_calculator_f_t;
+typedef struct sphericart_spherical_harmonics_calculator_f_t
+    sphericart_spherical_harmonics_calculator_f_t;
+
+/**
+ * Opaque type to hold a solid harmonics calculator object, that contains
+ * pre-computed factors and allocated buffer space for calculations.
+ *
+ * The `sphericart_solid_harmonics_calculator_t` performs calculations with `double` data type.
+ */
+struct sphericart_solid_harmonics_calculator_t;
+
+/**
+ * A type referring to the `sphericart_solid_harmonics_calculator_t` struct.
+ */
+typedef struct sphericart_solid_harmonics_calculator_t sphericart_solid_harmonics_calculator_t;
+
+/**
+ * Similar to `sphericart_solid_harmonics_calculator_t`, but operating on the `float` data
+ * type.
+ */
+struct sphericart_solid_harmonics_calculator_f_t;
+
+/**
+ * A type referring to the `sphericart_solid_harmonics_calculator_f_t` struct.
+ */
+typedef struct sphericart_solid_harmonics_calculator_f_t sphericart_solid_harmonics_calculator_f_t;
 #endif
 
 /**
@@ -51,39 +78,41 @@ typedef struct sphericart_calculator_f_t sphericart_calculator_f_t;
  *
  *  @param l_max The maximum degree of the spherical harmonics to be
  * calculated.
- *  @param normalized If `false`, computes the scaled spherical harmonics,
- * which are polynomials in the Cartesian coordinates of the input points. If
- *      `true`, computes the normalized spherical harmonics that are
- *      evaluated on the unit sphere. In practice, this simply computes the
- *      scaled harmonics at the normalized coordinates \f$(x/r, y/r, z/r)\f$,
- *      and adapts the derivatives accordingly.
  *
- *  @return A pointer to a `sphericart_calculator_t` object
+ *  @return A pointer to a `sphericart_spherical_harmonics_calculator_t` object
  *
  */
-SPHERICART_EXPORT sphericart_calculator_t* sphericart_new(size_t l_max, bool normalized);
+SPHERICART_EXPORT sphericart_spherical_harmonics_calculator_t* sphericart_spherical_harmonics_new(
+    size_t l_max
+);
 
 /**
- * Similar to `sphericart_new`, but it returns a `sphericart_calculator_f_t`,
- * which performs calculations on the `float` type.
+ * Similar to `sphericart_spherical_harmonics_new`, but it returns a
+ * `sphericart_spherical_harmonics_calculator_f_t`, which performs calculations on the `float` type.
  */
-SPHERICART_EXPORT sphericart_calculator_f_t* sphericart_new_f(size_t l_max, bool normalized);
+SPHERICART_EXPORT sphericart_spherical_harmonics_calculator_f_t* sphericart_spherical_harmonics_new_f(
+    size_t l_max
+);
 
 /**
- * Deletes a previously allocated `sphericart_calculator_t` calculator.
+ * Deletes a previously allocated `sphericart_spherical_harmonics_calculator_t` calculator.
  */
-SPHERICART_EXPORT void sphericart_delete(sphericart_calculator_t* calculator);
+SPHERICART_EXPORT void sphericart_spherical_harmonics_delete(
+    sphericart_spherical_harmonics_calculator_t* calculator
+);
 
 /**
- * Deletes a previously allocated `sphericart_calculator_f_t` calculator.
+ * Deletes a previously allocated `sphericart_spherical_harmonics_calculator_f_t` calculator.
  */
-SPHERICART_EXPORT void sphericart_delete_f(sphericart_calculator_f_t* calculator);
+SPHERICART_EXPORT void sphericart_spherical_harmonics_delete_f(
+    sphericart_spherical_harmonics_calculator_f_t* calculator
+);
 
 /**
  * This function calculates the spherical harmonics and, optionally, their
  * derivatives for an array of 3D points.
  *
- * @param calculator A pointer to a `sphericart_calculator_t` struct
+ * @param calculator A pointer to a `sphericart_spherical_harmonics_calculator_t` struct
  *        that holds prefactors and options to compute the spherical
  * harmonics.
  * @param xyz An array of size `n_samples x 3`. It contains the Cartesian
@@ -105,8 +134,8 @@ SPHERICART_EXPORT void sphericart_delete_f(sphericart_calculator_f_t* calculator
  * @param sph_length size of the sph allocation, should be `n_samples *
  * (l_max + 1) * (l_max + 1)`
  */
-SPHERICART_EXPORT void sphericart_compute_array(
-    sphericart_calculator_t* calculator,
+SPHERICART_EXPORT void sphericart_spherical_harmonics_compute_array(
+    sphericart_spherical_harmonics_calculator_t* calculator,
     const double* xyz,
     size_t xyz_length,
     double* sph,
@@ -117,7 +146,7 @@ SPHERICART_EXPORT void sphericart_compute_array(
  * This function calculates the spherical harmonics and their
  * derivatives for an array of 3D points.
  *
- * @param calculator A pointer to a `sphericart_calculator_t` struct
+ * @param calculator A pointer to a `sphericart_spherical_harmonics_calculator_t` struct
  *        that holds prefactors and options to compute the spherical
  * harmonics.
  * @param xyz An array of size `n_samples x 3`. It contains the Cartesian
@@ -151,8 +180,8 @@ SPHERICART_EXPORT void sphericart_compute_array(
  * @param dsph_length size of the dsph allocation, which should be `n_samples
  * * 3 * (l_max + 1) * (l_max + 1)`
  */
-SPHERICART_EXPORT void sphericart_compute_array_with_gradients(
-    sphericart_calculator_t* calculator,
+SPHERICART_EXPORT void sphericart_spherical_harmonics_compute_array_with_gradients(
+    sphericart_spherical_harmonics_calculator_t* calculator,
     const double* xyz,
     size_t xyz_length,
     double* sph,
@@ -165,7 +194,7 @@ SPHERICART_EXPORT void sphericart_compute_array_with_gradients(
  * This function calculates the spherical harmonics, their
  * derivatives and second derivatives for an array of 3D points.
  *
- * @param calculator A pointer to a `sphericart_calculator_t` struct
+ * @param calculator A pointer to a `sphericart_spherical_harmonics_calculator_t` struct
  *        that holds prefactors and options to compute the spherical
  * harmonics.
  * @param xyz An array of size `n_samples x 3`. It contains the Cartesian
@@ -211,8 +240,8 @@ SPHERICART_EXPORT void sphericart_compute_array_with_gradients(
  * @param ddsph_length size of the dsph allocation, which should be
  * `n_samples * 3 * 3* (l_max + 1) * (l_max + 1)`
  */
-SPHERICART_EXPORT void sphericart_compute_array_with_hessians(
-    sphericart_calculator_t* calculator,
+SPHERICART_EXPORT void sphericart_spherical_harmonics_compute_array_with_hessians(
+    sphericart_spherical_harmonics_calculator_t* calculator,
     const double* xyz,
     size_t xyz_length,
     double* sph,
@@ -224,11 +253,11 @@ SPHERICART_EXPORT void sphericart_compute_array_with_hessians(
 );
 
 /**
- * Similar to :func:`sphericart_compute_array`, but it computes the spherical
+ * Similar to :func:`sphericart_spherical_harmonics_compute_array`, but it computes the spherical
  * harmonics for a single 3D point in space.
  */
-SPHERICART_EXPORT void sphericart_compute_sample(
-    sphericart_calculator_t* calculator,
+SPHERICART_EXPORT void sphericart_spherical_harmonics_compute_sample(
+    sphericart_spherical_harmonics_calculator_t* calculator,
     const double* xyz,
     size_t xyz_length,
     double* sph,
@@ -236,11 +265,11 @@ SPHERICART_EXPORT void sphericart_compute_sample(
 );
 
 /**
- * Similar to :func:`sphericart_compute_array_with_gradients`, but it
+ * Similar to :func:`sphericart_spherical_harmonics_compute_array_with_gradients`, but it
  * computes the spherical harmonics for a single 3D point in space.
  */
-SPHERICART_EXPORT void sphericart_compute_sample_with_gradients(
-    sphericart_calculator_t* calculator,
+SPHERICART_EXPORT void sphericart_spherical_harmonics_compute_sample_with_gradients(
+    sphericart_spherical_harmonics_calculator_t* calculator,
     const double* xyz,
     size_t xyz_length,
     double* sph,
@@ -250,11 +279,11 @@ SPHERICART_EXPORT void sphericart_compute_sample_with_gradients(
 );
 
 /**
- * Similar to :func:`sphericart_compute_array_with_hessians`, but it computes
+ * Similar to :func:`sphericart_spherical_harmonics_compute_array_with_hessians`, but it computes
  * the spherical harmonics for a single 3D point in space.
  */
-SPHERICART_EXPORT void sphericart_compute_sample_with_hessians(
-    sphericart_calculator_t* calculator,
+SPHERICART_EXPORT void sphericart_spherical_harmonics_compute_sample_with_hessians(
+    sphericart_spherical_harmonics_calculator_t* calculator,
     const double* xyz,
     size_t xyz_length,
     double* sph,
@@ -266,11 +295,11 @@ SPHERICART_EXPORT void sphericart_compute_sample_with_hessians(
 );
 
 /**
- * Similar to :func:`sphericart_compute_array`, but using the `float` data
+ * Similar to :func:`sphericart_spherical_harmonics_compute_array`, but using the `float` data
  * type.
  */
-SPHERICART_EXPORT void sphericart_compute_array_f(
-    sphericart_calculator_f_t* calculator,
+SPHERICART_EXPORT void sphericart_spherical_harmonics_compute_array_f(
+    sphericart_spherical_harmonics_calculator_f_t* calculator,
     const float* xyz,
     size_t xyz_length,
     float* sph,
@@ -278,11 +307,11 @@ SPHERICART_EXPORT void sphericart_compute_array_f(
 );
 
 /**
- * Similar to :func:`sphericart_compute_array_with_gradients`, but using the
+ * Similar to :func:`sphericart_spherical_harmonics_compute_array_with_gradients`, but using the
  * `float` data type.
  */
-SPHERICART_EXPORT void sphericart_compute_array_with_gradients_f(
-    sphericart_calculator_f_t* calculator,
+SPHERICART_EXPORT void sphericart_spherical_harmonics_compute_array_with_gradients_f(
+    sphericart_spherical_harmonics_calculator_f_t* calculator,
     const float* xyz,
     size_t xyz_length,
     float* sph,
@@ -292,53 +321,11 @@ SPHERICART_EXPORT void sphericart_compute_array_with_gradients_f(
 );
 
 /**
- * Similar to :func:`sphericart_compute_array_with_hessians`, but using the
+ * Similar to :func:`sphericart_spherical_harmonics_compute_array_with_hessians`, but using the
  * `float` data type.
  */
-SPHERICART_EXPORT void sphericart_compute_array_with_hessians_f(
-    sphericart_calculator_f_t* calculator,
-    const float* xyz,
-    size_t xyz_length,
-    float* sph,
-    size_t sph_length,
-    float* dsph,
-    size_t dsph_length,
-    float* ddsph,
-    size_t ddsph_length
-);
-
-/**
- * Similar to :func:`sphericart_compute_sample`, but using the `float` data
- * type.
- */
-SPHERICART_EXPORT void sphericart_compute_sample_f(
-    sphericart_calculator_f_t* calculator,
-    const float* xyz,
-    size_t xyz_length,
-    float* sph,
-    size_t sph_length
-);
-
-/**
- * Similar to :func:`sphericart_compute_sample_with_gradients`, but using the
- * `float` data type.
- */
-SPHERICART_EXPORT void sphericart_compute_sample_with_gradients_f(
-    sphericart_calculator_f_t* calculator,
-    const float* xyz,
-    size_t xyz_length,
-    float* sph,
-    size_t sph_length,
-    float* dsph,
-    size_t dsph_length
-);
-
-/**
- * Similar to :func:`sphericart_compute_sample_with_hessians`, but using the
- * `float` data type.
- */
-SPHERICART_EXPORT void sphericart_compute_sample_with_hessians_f(
-    sphericart_calculator_f_t* calculator,
+SPHERICART_EXPORT void sphericart_spherical_harmonics_compute_array_with_hessians_f(
+    sphericart_spherical_harmonics_calculator_f_t* calculator,
     const float* xyz,
     size_t xyz_length,
     float* sph,
@@ -353,9 +340,372 @@ SPHERICART_EXPORT void sphericart_compute_sample_with_hessians_f(
  * Get the number of OpenMP threads used by a calculator.
  * If `sphericart` is computed without OpenMP support returns 1.
  */
-SPHERICART_EXPORT int sphericart_omp_num_threads(sphericart_calculator_t* calculator);
+SPHERICART_EXPORT int sphericart_spherical_harmonics_omp_num_threads(
+    sphericart_spherical_harmonics_calculator_t* calculator
+);
 
-SPHERICART_EXPORT int sphericart_omp_num_threads_f(sphericart_calculator_f_t* calculator);
+SPHERICART_EXPORT int sphericart_spherical_harmonics_omp_num_threads_f(
+    sphericart_spherical_harmonics_calculator_f_t* calculator
+);
+
+/**
+ * Similar to :func:`sphericart_spherical_harmonics_compute_sample`, but using the `float` data
+ * type.
+ */
+SPHERICART_EXPORT void sphericart_spherical_harmonics_compute_sample_f(
+    sphericart_spherical_harmonics_calculator_f_t* calculator,
+    const float* xyz,
+    size_t xyz_length,
+    float* sph,
+    size_t sph_length
+);
+
+/**
+ * Similar to :func:`sphericart_spherical_harmonics_compute_sample_with_gradients`, but using the
+ * `float` data type.
+ */
+SPHERICART_EXPORT void sphericart_spherical_harmonics_compute_sample_with_gradients_f(
+    sphericart_spherical_harmonics_calculator_f_t* calculator,
+    const float* xyz,
+    size_t xyz_length,
+    float* sph,
+    size_t sph_length,
+    float* dsph,
+    size_t dsph_length
+);
+
+/**
+ * Similar to :func:`sphericart_spherical_harmonics_compute_sample_with_hessians`, but using the
+ * `float` data type.
+ */
+SPHERICART_EXPORT void sphericart_spherical_harmonics_compute_sample_with_hessians_f(
+    sphericart_spherical_harmonics_calculator_f_t* calculator,
+    const float* xyz,
+    size_t xyz_length,
+    float* sph,
+    size_t sph_length,
+    float* dsph,
+    size_t dsph_length,
+    float* ddsph,
+    size_t ddsph_length
+);
+
+/**
+ * Initializes a solid harmonics calculator and returns a pointer that
+ * can then be used by functions that evaluate solid harmonics over
+ * arrays or individual samples.
+ *
+ *  @param l_max The maximum degree of the solid harmonics to be
+ * calculated.
+ *
+ *  @return A pointer to a `sphericart_solid_harmonics_calculator_t` object
+ *
+ */
+SPHERICART_EXPORT sphericart_solid_harmonics_calculator_t* sphericart_solid_harmonics_new(size_t l_max
+);
+
+/**
+ * Similar to `sphericart_solid_harmonics_new`, but it returns a
+ * `sphericart_solid_harmonics_calculator_f_t`, which performs calculations on the `float` type.
+ */
+SPHERICART_EXPORT sphericart_solid_harmonics_calculator_f_t* sphericart_solid_harmonics_new_f(size_t l_max
+);
+
+/**
+ * Deletes a previously allocated `sphericart_solid_harmonics_calculator_t` calculator.
+ */
+SPHERICART_EXPORT void sphericart_solid_harmonics_delete(
+    sphericart_solid_harmonics_calculator_t* calculator
+);
+
+/**
+ * Deletes a previously allocated `sphericart_solid_harmonics_calculator_f_t` calculator.
+ */
+SPHERICART_EXPORT void sphericart_solid_harmonics_delete_f(
+    sphericart_solid_harmonics_calculator_f_t* calculator
+);
+
+/**
+ * This function calculates the solid harmonics and, optionally, their
+ * derivatives for an array of 3D points.
+ *
+ * @param calculator A pointer to a `sphericart_solid_harmonics_calculator_t` struct
+ *        that holds prefactors and options to compute the solid
+ * harmonics.
+ * @param xyz An array of size `n_samples x 3`. It contains the Cartesian
+ *        coordinates of the 3D points for which the solid harmonics are
+ * to be computed, organized along two dimensions. The outer dimension is
+ *        `n_samples` long, accounting for different samples, while the inner
+ *        dimension has size 3 and it represents the x, y, and z coordinates
+ *        respectively.
+ * @param xyz_length size of the xyz allocation, i.e, `3 * n_samples`
+ * @param sph pointer to the first element of an array containing `n_samples
+ * * (l_max + 1) * (l_max + 1)` elements. On exit, this array will contain
+ *        the solid harmonics organized along two dimensions. The leading
+ *        dimension is `n_samples` long and it represents the different
+ * samples, while the inner dimension size is `(l_max + 1) * (l_max + 1)`
+ * long and it contains the solid harmonics. These are laid out in
+ *        lexicographic order. For example, if `l_max=2`, it will contain
+ * `(l, m) = (0, 0), (1, -1), (1, 0), (1, 1), (2, -2), (2, -1), (2, 0), (2,
+ *        1), (2, 2)`, in this order.
+ * @param sph_length size of the sph allocation, should be `n_samples *
+ * (l_max + 1) * (l_max + 1)`
+ */
+SPHERICART_EXPORT void sphericart_solid_harmonics_compute_array(
+    sphericart_solid_harmonics_calculator_t* calculator,
+    const double* xyz,
+    size_t xyz_length,
+    double* sph,
+    size_t sph_length
+);
+
+/**
+ * This function calculates the solid harmonics and their
+ * derivatives for an array of 3D points.
+ *
+ * @param calculator A pointer to a `sphericart_solid_harmonics_calculator_t` struct
+ *        that holds prefactors and options to compute the solid
+ * harmonics.
+ * @param xyz An array of size `n_samples x 3`. It contains the Cartesian
+ *        coordinates of the 3D points for which the solid harmonics are
+ * to be computed, organized along two dimensions. The outer dimension is
+ *        `n_samples` long, accounting for different samples, while the inner
+ *        dimension has size 3 and it represents the x, y, and z coordinates
+ *        respectively.
+ * @param xyz_length size of the xyz allocation, i.e, `3 * n_samples`
+ * @param sph pointer to the first element of an array containing `n_samples
+ * * (l_max + 1) * (l_max + 1)` elements. On exit, this array will contain
+ *        the solid harmonics organized along two dimensions. The leading
+ *        dimension is `n_samples` long and it represents the different
+ * samples, while the inner dimension size is `(l_max + 1) * (l_max + 1)`
+ * long and it contains the solid harmonics. These are laid out in
+ *        lexicographic order. For example, if `l_max=2`, it will contain
+ * `(l, m) = (0, 0), (1, -1), (1, 0), (1, 1), (2, -2), (2, -1), (2, 0), (2,
+ *        1), (2, 2)`, in this order.
+ * @param sph_length size of the sph allocation, should be `n_samples *
+ * (l_max + 1) * (l_max + 1)`
+ * @param dsph pointer to the first element of an array containing `n_samples
+ * * `n_samples * 3 * (l_max + 1) * (l_max + 1)` elements. On exit, this
+ *         array will contain the solid harmonics' derivatives organized
+ *         along three dimensions. As for the `sph` parameter, the leading
+ *         dimension represents the different samples, while the inner-most
+ *         dimension size is `(l_max + 1) * (l_max + 1)`, and it represents
+ * the degree and order of the solid harmonics (again, organized in
+ *         lexicographic order). The intermediate dimension corresponds to
+ *         different spatial derivatives of the solid harmonics: x, y,
+ * and z, respectively.
+ * @param dsph_length size of the dsph allocation, which should be `n_samples
+ * * 3 * (l_max + 1) * (l_max + 1)`
+ */
+SPHERICART_EXPORT void sphericart_solid_harmonics_compute_array_with_gradients(
+    sphericart_solid_harmonics_calculator_t* calculator,
+    const double* xyz,
+    size_t xyz_length,
+    double* sph,
+    size_t sph_length,
+    double* dsph,
+    size_t dsph_length
+);
+
+/**
+ * This function calculates the solid harmonics, their
+ * derivatives and second derivatives for an array of 3D points.
+ *
+ * @param calculator A pointer to a `sphericart_solid_harmonics_calculator_t` struct
+ *        that holds prefactors and options to compute the solid
+ * harmonics.
+ * @param xyz An array of size `n_samples x 3`. It contains the Cartesian
+ *        coordinates of the 3D points for which the solid harmonics are
+ * to be computed, organized along two dimensions. The outer dimension is
+ *        `n_samples` long, accounting for different samples, while the inner
+ *        dimension has size 3 and it represents the x, y, and z coordinates
+ *        respectively.
+ * @param xyz_length size of the xyz allocation, i.e, `3 * n_samples`
+ * @param sph pointer to the first element of an array containing `n_samples
+ * * (l_max + 1) * (l_max + 1)` elements. On exit, this array will contain
+ *        the solid harmonics organized along two dimensions. The leading
+ *        dimension is `n_samples` long and it represents the different
+ * samples, while the inner dimension size is `(l_max + 1) * (l_max + 1)`
+ * long and it contains the solid harmonics. These are laid out in
+ *        lexicographic order. For example, if `l_max=2`, it will contain
+ * `(l, m) = (0, 0), (1, -1), (1, 0), (1, 1), (2, -2), (2, -1), (2, 0), (2,
+ *        1), (2, 2)`, in this order.
+ * @param sph_length size of the sph allocation, should be `n_samples *
+ * (l_max + 1) * (l_max + 1)`
+ * @param dsph pointer to the first element of an array containing
+ *         `n_samples * 3 * (l_max + 1) * (l_max + 1)` elements. On exit,
+ * this array will contain the solid harmonics' derivatives organized
+ *         along three dimensions. As for the `sph` parameter, the leading
+ *         dimension represents the different samples, while the inner-most
+ *         dimension size is `(l_max + 1) * (l_max + 1)`, and it represents
+ * the degree and order of the solid harmonics (again, organized in
+ *         lexicographic order). The intermediate dimension corresponds to
+ *         different spatial derivatives of the solid harmonics: x, y,
+ * and z, respectively.
+ * @param dsph_length size of the dsph allocation, which should be `n_samples
+ * * 3 * (l_max + 1) * (l_max + 1)`
+ * @param ddsph pointer to the first element of an array containing
+ *        `n_samples * 3 * 3 * (l_max + 1) * (l_max + 1)` elements. On exit,
+ * this array will contain the solid harmonics' second derivatives
+ * organized along four dimensions. As for the `sph` parameter, the leading
+ * dimension represents the different samples, while the inner-most dimension
+ * size is `(l_max + 1) * (l_max + 1)`, and it represents the degree and
+ * order of the solid harmonics (again, organized in lexicographic
+ * order). The intermediate dimensions correspond to the different spatial
+ * second derivatives of the solid harmonics, i.e., to the dimensions of
+ * the hessian matrix.
+ * @param ddsph_length size of the dsph allocation, which should be
+ * `n_samples * 3 * 3* (l_max + 1) * (l_max + 1)`
+ */
+SPHERICART_EXPORT void sphericart_solid_harmonics_compute_array_with_hessians(
+    sphericart_solid_harmonics_calculator_t* calculator,
+    const double* xyz,
+    size_t xyz_length,
+    double* sph,
+    size_t sph_length,
+    double* dsph,
+    size_t dsph_length,
+    double* ddsph,
+    size_t ddsph_length
+);
+
+/**
+ * Similar to :func:`sphericart_solid_harmonics_compute_array`, but it computes the solid
+ * harmonics for a single 3D point in space.
+ */
+SPHERICART_EXPORT void sphericart_solid_harmonics_compute_sample(
+    sphericart_solid_harmonics_calculator_t* calculator,
+    const double* xyz,
+    size_t xyz_length,
+    double* sph,
+    size_t sph_length
+);
+
+/**
+ * Similar to :func:`sphericart_solid_harmonics_compute_array_with_gradients`, but it
+ * computes the solid harmonics for a single 3D point in space.
+ */
+SPHERICART_EXPORT void sphericart_solid_harmonics_compute_sample_with_gradients(
+    sphericart_solid_harmonics_calculator_t* calculator,
+    const double* xyz,
+    size_t xyz_length,
+    double* sph,
+    size_t sph_length,
+    double* dsph,
+    size_t dsph_length
+);
+
+/**
+ * Similar to :func:`sphericart_solid_harmonics_compute_array_with_hessians`, but it computes
+ * the solid harmonics for a single 3D point in space.
+ */
+SPHERICART_EXPORT void sphericart_solid_harmonics_compute_sample_with_hessians(
+    sphericart_solid_harmonics_calculator_t* calculator,
+    const double* xyz,
+    size_t xyz_length,
+    double* sph,
+    size_t sph_length,
+    double* dsph,
+    size_t dsph_length,
+    double* ddsph,
+    size_t ddsph_length
+);
+
+/**
+ * Similar to :func:`sphericart_solid_harmonics_compute_array`, but using the `float` data
+ * type.
+ */
+SPHERICART_EXPORT void sphericart_solid_harmonics_compute_array_f(
+    sphericart_solid_harmonics_calculator_f_t* calculator,
+    const float* xyz,
+    size_t xyz_length,
+    float* sph,
+    size_t sph_length
+);
+
+/**
+ * Similar to :func:`sphericart_solid_harmonics_compute_array_with_gradients`, but using the
+ * `float` data type.
+ */
+SPHERICART_EXPORT void sphericart_solid_harmonics_compute_array_with_gradients_f(
+    sphericart_solid_harmonics_calculator_f_t* calculator,
+    const float* xyz,
+    size_t xyz_length,
+    float* sph,
+    size_t sph_length,
+    float* dsph,
+    size_t dsph_length
+);
+
+/**
+ * Similar to :func:`sphericart_solid_harmonics_compute_array_with_hessians`, but using the
+ * `float` data type.
+ */
+SPHERICART_EXPORT void sphericart_solid_harmonics_compute_array_with_hessians_f(
+    sphericart_solid_harmonics_calculator_f_t* calculator,
+    const float* xyz,
+    size_t xyz_length,
+    float* sph,
+    size_t sph_length,
+    float* dsph,
+    size_t dsph_length,
+    float* ddsph,
+    size_t ddsph_length
+);
+
+/**
+ * Similar to :func:`sphericart_solid_harmonics_compute_sample`, but using the `float` data
+ * type.
+ */
+SPHERICART_EXPORT void sphericart_solid_harmonics_compute_sample_f(
+    sphericart_solid_harmonics_calculator_f_t* calculator,
+    const float* xyz,
+    size_t xyz_length,
+    float* sph,
+    size_t sph_length
+);
+
+/**
+ * Similar to :func:`sphericart_solid_harmonics_compute_sample_with_gradients`, but using the
+ * `float` data type.
+ */
+SPHERICART_EXPORT void sphericart_solid_harmonics_compute_sample_with_gradients_f(
+    sphericart_solid_harmonics_calculator_f_t* calculator,
+    const float* xyz,
+    size_t xyz_length,
+    float* sph,
+    size_t sph_length,
+    float* dsph,
+    size_t dsph_length
+);
+
+/**
+ * Similar to :func:`sphericart_solid_harmonics_compute_sample_with_hessians`, but using the
+ * `float` data type.
+ */
+SPHERICART_EXPORT void sphericart_solid_harmonics_compute_sample_with_hessians_f(
+    sphericart_solid_harmonics_calculator_f_t* calculator,
+    const float* xyz,
+    size_t xyz_length,
+    float* sph,
+    size_t sph_length,
+    float* dsph,
+    size_t dsph_length,
+    float* ddsph,
+    size_t ddsph_length
+);
+
+/**
+ * Get the number of OpenMP threads used by a calculator.
+ * If `sphericart` is computed without OpenMP support returns 1.
+ */
+SPHERICART_EXPORT int sphericart_solid_harmonics_omp_num_threads(
+    sphericart_solid_harmonics_calculator_t* calculator
+);
+
+SPHERICART_EXPORT int sphericart_solid_harmonics_omp_num_threads_f(
+    sphericart_solid_harmonics_calculator_f_t* calculator
+);
 
 #ifdef __cplusplus
 }

--- a/sphericart/include/sphericart.hpp
+++ b/sphericart/include/sphericart.hpp
@@ -30,15 +30,8 @@ template <typename T> class SphericalHarmonics {
      *
      *  @param l_max
      *      The maximum degree of the spherical harmonics to be calculated.
-     *  @param normalized
-     *      If `false` (default) computes the scaled spherical harmonics, which
-     * are homogeneous polynomials in the Cartesian coordinates of the input
-     * points. If `true`, computes the normalized spherical harmonics that are
-     * evaluated on the unit sphere. In practice, this simply computes the
-     * scaled harmonics at the normalized coordinates \f$(x/r, y/r, z/r)\f$, and
-     * adapts the derivatives accordingly.
      */
-    SphericalHarmonics(size_t l_max, bool normalized = false);
+    SphericalHarmonics(size_t l_max);
 
     /* @cond */
     ~SphericalHarmonics();
@@ -364,12 +357,12 @@ template <typename T> class SphericalHarmonics {
     */
     int get_omp_num_threads() { return this->omp_num_threads; }
 
+    template <typename U> friend class SolidHarmonics;
     /* @cond */
   private:
     size_t l_max;        // maximum l value computed by this class
     size_t size_y;       // size of the Ylm rows (l_max+1)**2
     size_t size_q;       // size of the prefactor-like arrays (l_max+1)*(l_max+2)/2
-    bool normalized;     // should we normalize the input vectors?
     int omp_num_threads; // number of openmp thread
     T* prefactors;       // storage space for prefactor and buffers
     T* buffers;
@@ -386,6 +379,17 @@ template <typename T> class SphericalHarmonics {
     void (*_sample_with_derivatives)(const T*, T*, T*, T*, int, int, const T*, const T*, T*, T*, T*);
     void (*_sample_with_hessians)(const T*, T*, T*, T*, int, int, const T*, const T*, T*, T*, T*);
     /* @endcond */
+};
+
+template <typename T> class SolidHarmonics : public SphericalHarmonics<T> {
+  public:
+    /** Initialize the SphericalHarmonics class setting maximum degree and
+     * normalization
+     *
+     *  @param l_max
+     *      The maximum degree of the spherical harmonics to be calculated.
+     */
+    SolidHarmonics(size_t l_max);
 };
 
 } // namespace sphericart

--- a/sphericart/include/sphericart_cuda.hpp
+++ b/sphericart/include/sphericart_cuda.hpp
@@ -31,15 +31,8 @@ template <typename T> class SphericalHarmonics {
      *
      *  @param l_max
      *      The maximum degree of the spherical harmonics to be calculated.
-     *  @param normalized
-     *      If `false` (default) computes the scaled spherical harmonics, which
-     * are homogeneous polynomials in the Cartesian coordinates of the input
-     * points. If `true`, computes the normalized spherical harmonics that are
-     * evaluated on the unit sphere. In practice, this simply computes the
-     * scaled harmonics at the normalized coordinates \f$(x/r, y/r, z/r)\f$, and
-     * adapts the derivatives accordingly.
      */
-    SphericalHarmonics(size_t l_max, bool normalized = false);
+    SphericalHarmonics(size_t l_max);
 
     /** Default constructor
      * Required so sphericart_torch can conditionally instantiate  this class
@@ -96,6 +89,7 @@ template <typename T> class SphericalHarmonics {
         void* cuda_stream = nullptr
     );
 
+    template <typename U> friend class SolidHarmonics;
     /* @cond */
   private:
     size_t l_max; // maximum l value computed by this class
@@ -110,6 +104,17 @@ template <typename T> class SphericalHarmonics {
     bool cached_compute_with_hessian = false;
     int64_t _current_shared_mem_allocation = 0;
     /* @endcond */
+};
+
+template <typename T> class SolidHarmonics : public SphericalHarmonics<T> {
+  public:
+    /** Initialize the SolidHarmonics class setting maximum degree and
+     * normalization
+     *
+     *  @param l_max
+     *      The maximum degree of the spherical harmonics to be calculated.
+     */
+    SolidHarmonics(size_t l_max);
 };
 
 } // namespace cuda

--- a/sphericart/src/sphericart-capi.cpp
+++ b/sphericart/src/sphericart-capi.cpp
@@ -3,16 +3,19 @@
 #include "sphericart.h"
 #include "sphericart.hpp"
 
-extern "C" sphericart_calculator_t* sphericart_new(size_t l_max, bool normalized) {
+extern "C" sphericart_spherical_harmonics_calculator_t* sphericart_spherical_harmonics_new(size_t l_max
+) {
     try {
-        return new sphericart::SphericalHarmonics<double>(l_max, normalized);
+        return new sphericart::SphericalHarmonics<double>(l_max);
     } catch (...) {
         // TODO: better error handling
         return nullptr;
     }
 }
 
-extern "C" void sphericart_delete(sphericart_calculator_t* calculator) {
+extern "C" void sphericart_spherical_harmonics_delete(
+    sphericart_spherical_harmonics_calculator_t* calculator
+) {
     try {
         delete calculator;
     } catch (...) {
@@ -20,8 +23,8 @@ extern "C" void sphericart_delete(sphericart_calculator_t* calculator) {
     }
 }
 
-extern "C" void sphericart_compute_array(
-    sphericart_calculator_t* calculator,
+extern "C" void sphericart_spherical_harmonics_compute_array(
+    sphericart_spherical_harmonics_calculator_t* calculator,
     const double* xyz,
     size_t xyz_length,
     double* sph,
@@ -39,8 +42,8 @@ extern "C" void sphericart_compute_array(
     }
 }
 
-extern "C" void sphericart_compute_array_with_gradients(
-    sphericart_calculator_t* calculator,
+extern "C" void sphericart_spherical_harmonics_compute_array_with_gradients(
+    sphericart_spherical_harmonics_calculator_t* calculator,
     const double* xyz,
     size_t xyz_length,
     double* sph,
@@ -60,8 +63,8 @@ extern "C" void sphericart_compute_array_with_gradients(
     }
 }
 
-extern "C" void sphericart_compute_array_with_hessians(
-    sphericart_calculator_t* calculator,
+extern "C" void sphericart_spherical_harmonics_compute_array_with_hessians(
+    sphericart_spherical_harmonics_calculator_t* calculator,
     const double* xyz,
     size_t xyz_length,
     double* sph,
@@ -85,8 +88,8 @@ extern "C" void sphericart_compute_array_with_hessians(
     }
 }
 
-extern "C" void sphericart_compute_sample(
-    sphericart_calculator_t* calculator,
+extern "C" void sphericart_spherical_harmonics_compute_sample(
+    sphericart_spherical_harmonics_calculator_t* calculator,
     const double* xyz,
     size_t xyz_length,
     double* sph,
@@ -104,8 +107,8 @@ extern "C" void sphericart_compute_sample(
     }
 }
 
-extern "C" void sphericart_compute_sample_with_gradients(
-    sphericart_calculator_t* calculator,
+extern "C" void sphericart_spherical_harmonics_compute_sample_with_gradients(
+    sphericart_spherical_harmonics_calculator_t* calculator,
     const double* xyz,
     size_t xyz_length,
     double* sph,
@@ -127,8 +130,8 @@ extern "C" void sphericart_compute_sample_with_gradients(
     }
 }
 
-extern "C" void sphericart_compute_sample_with_hessians(
-    sphericart_calculator_t* calculator,
+extern "C" void sphericart_spherical_harmonics_compute_sample_with_hessians(
+    sphericart_spherical_harmonics_calculator_t* calculator,
     const double* xyz,
     size_t xyz_length,
     double* sph,
@@ -152,16 +155,20 @@ extern "C" void sphericart_compute_sample_with_hessians(
     }
 }
 
-extern "C" sphericart_calculator_f_t* sphericart_new_f(size_t l_max, bool normalized) {
+extern "C" sphericart_spherical_harmonics_calculator_f_t* sphericart_spherical_harmonics_new_f(
+    size_t l_max
+) {
     try {
-        return new sphericart::SphericalHarmonics<float>(l_max, normalized);
+        return new sphericart::SphericalHarmonics<float>(l_max);
     } catch (...) {
         // TODO: better error handling
         return nullptr;
     }
 }
 
-extern "C" void sphericart_delete_f(sphericart_calculator_f_t* calculator) {
+extern "C" void sphericart_spherical_harmonics_delete_f(
+    sphericart_spherical_harmonics_calculator_f_t* calculator
+) {
     try {
         delete calculator;
     } catch (...) {
@@ -169,8 +176,8 @@ extern "C" void sphericart_delete_f(sphericart_calculator_f_t* calculator) {
     }
 }
 
-extern "C" void sphericart_compute_array_f(
-    sphericart_calculator_f_t* calculator,
+extern "C" void sphericart_spherical_harmonics_compute_array_f(
+    sphericart_spherical_harmonics_calculator_f_t* calculator,
     const float* xyz,
     size_t xyz_length,
     float* sph,
@@ -188,8 +195,8 @@ extern "C" void sphericart_compute_array_f(
     }
 }
 
-extern "C" void sphericart_compute_array_with_gradients_f(
-    sphericart_calculator_f_t* calculator,
+extern "C" void sphericart_spherical_harmonics_compute_array_with_gradients_f(
+    sphericart_spherical_harmonics_calculator_f_t* calculator,
     const float* xyz,
     size_t xyz_length,
     float* sph,
@@ -209,8 +216,8 @@ extern "C" void sphericart_compute_array_with_gradients_f(
     }
 }
 
-extern "C" void sphericart_compute_array_with_hessians_f(
-    sphericart_calculator_f_t* calculator,
+extern "C" void sphericart_spherical_harmonics_compute_array_with_hessians_f(
+    sphericart_spherical_harmonics_calculator_f_t* calculator,
     const float* xyz,
     size_t xyz_length,
     float* sph,
@@ -234,8 +241,8 @@ extern "C" void sphericart_compute_array_with_hessians_f(
     }
 }
 
-extern "C" void sphericart_compute_sample_f(
-    sphericart_calculator_f_t* calculator,
+extern "C" void sphericart_spherical_harmonics_compute_sample_f(
+    sphericart_spherical_harmonics_calculator_f_t* calculator,
     const float* xyz,
     size_t xyz_length,
     float* sph,
@@ -253,8 +260,8 @@ extern "C" void sphericart_compute_sample_f(
     }
 }
 
-extern "C" void sphericart_compute_sample_with_gradients_f(
-    sphericart_calculator_f_t* calculator,
+extern "C" void sphericart_spherical_harmonics_compute_sample_with_gradients_f(
+    sphericart_spherical_harmonics_calculator_f_t* calculator,
     const float* xyz,
     size_t xyz_length,
     float* sph,
@@ -276,8 +283,8 @@ extern "C" void sphericart_compute_sample_with_gradients_f(
     }
 }
 
-extern "C" void sphericart_compute_sample_with_hessians_f(
-    sphericart_calculator_f_t* calculator,
+extern "C" void sphericart_spherical_harmonics_compute_sample_with_hessians_f(
+    sphericart_spherical_harmonics_calculator_f_t* calculator,
     const float* xyz,
     size_t xyz_length,
     float* sph,
@@ -301,10 +308,326 @@ extern "C" void sphericart_compute_sample_with_hessians_f(
     }
 }
 
-extern "C" int sphericart_omp_num_threads(sphericart_calculator_t* calculator) {
+extern "C" int sphericart_spherical_harmonics_omp_num_threads(
+    sphericart_spherical_harmonics_calculator_t* calculator
+) {
     return calculator->get_omp_num_threads();
 }
 
-extern "C" int sphericart_omp_num_threads_f(sphericart_calculator_f_t* calculator) {
+extern "C" int sphericart_spherical_harmonics_omp_num_threads_f(
+    sphericart_spherical_harmonics_calculator_f_t* calculator
+) {
+    return calculator->get_omp_num_threads();
+}
+
+extern "C" sphericart_solid_harmonics_calculator_t* sphericart_solid_harmonics_new(size_t l_max) {
+    try {
+        return new sphericart::SolidHarmonics<double>(l_max);
+    } catch (...) {
+        // TODO: better error handling
+        return nullptr;
+    }
+}
+
+extern "C" void sphericart_solid_harmonics_delete(sphericart_solid_harmonics_calculator_t* calculator
+) {
+    try {
+        delete calculator;
+    } catch (...) {
+        // nothing to do
+    }
+}
+
+extern "C" void sphericart_solid_harmonics_compute_array(
+    sphericart_solid_harmonics_calculator_t* calculator,
+    const double* xyz,
+    size_t xyz_length,
+    double* sph,
+    size_t sph_length
+) {
+    try {
+        calculator->compute_array(xyz, xyz_length, sph, sph_length);
+    } catch (const std::exception& e) {
+        // TODO: better error handling
+        printf("fatal error: %s\n", e.what());
+        abort();
+    } catch (...) {
+        printf("fatal error: unknown exception type\n");
+        abort();
+    }
+}
+
+extern "C" void sphericart_solid_harmonics_compute_array_with_gradients(
+    sphericart_solid_harmonics_calculator_t* calculator,
+    const double* xyz,
+    size_t xyz_length,
+    double* sph,
+    size_t sph_length,
+    double* dsph,
+    size_t dsph_length
+) {
+    try {
+        calculator->compute_array_with_gradients(xyz, xyz_length, sph, sph_length, dsph, dsph_length);
+    } catch (const std::exception& e) {
+        // TODO: better error handling
+        printf("fatal error: %s\n", e.what());
+        abort();
+    } catch (...) {
+        printf("fatal error: unknown exception type\n");
+        abort();
+    }
+}
+
+extern "C" void sphericart_solid_harmonics_compute_array_with_hessians(
+    sphericart_solid_harmonics_calculator_t* calculator,
+    const double* xyz,
+    size_t xyz_length,
+    double* sph,
+    size_t sph_length,
+    double* dsph,
+    size_t dsph_length,
+    double* ddsph,
+    size_t ddsph_length
+) {
+    try {
+        calculator->compute_array_with_hessians(
+            xyz, xyz_length, sph, sph_length, dsph, dsph_length, ddsph, ddsph_length
+        );
+    } catch (const std::exception& e) {
+        // TODO: better error handling
+        printf("fatal error: %s\n", e.what());
+        abort();
+    } catch (...) {
+        printf("fatal error: unknown exception type\n");
+        abort();
+    }
+}
+
+extern "C" void sphericart_solid_harmonics_compute_sample(
+    sphericart_solid_harmonics_calculator_t* calculator,
+    const double* xyz,
+    size_t xyz_length,
+    double* sph,
+    size_t sph_length
+) {
+    try {
+        calculator->compute_sample(xyz, xyz_length, sph, sph_length);
+    } catch (const std::exception& e) {
+        // TODO: better error handling
+        printf("fatal error: %s\n", e.what());
+        abort();
+    } catch (...) {
+        printf("fatal error: unknown exception type\n");
+        abort();
+    }
+}
+
+extern "C" void sphericart_solid_harmonics_compute_sample_with_gradients(
+    sphericart_solid_harmonics_calculator_t* calculator,
+    const double* xyz,
+    size_t xyz_length,
+    double* sph,
+    size_t sph_length,
+    double* dsph,
+    size_t dsph_length
+) {
+    try {
+        calculator->compute_sample_with_gradients(
+            xyz, xyz_length, sph, sph_length, dsph, dsph_length
+        );
+    } catch (const std::exception& e) {
+        // TODO: better error handling
+        printf("fatal error: %s\n", e.what());
+        abort();
+    } catch (...) {
+        printf("fatal error: unknown exception type\n");
+        abort();
+    }
+}
+
+extern "C" void sphericart_solid_harmonics_compute_sample_with_hessians(
+    sphericart_solid_harmonics_calculator_t* calculator,
+    const double* xyz,
+    size_t xyz_length,
+    double* sph,
+    size_t sph_length,
+    double* dsph,
+    size_t dsph_length,
+    double* ddsph,
+    size_t ddsph_length
+) {
+    try {
+        calculator->compute_sample_with_hessians(
+            xyz, xyz_length, sph, sph_length, dsph, dsph_length, ddsph, ddsph_length
+        );
+    } catch (const std::exception& e) {
+        // TODO: better error handling
+        printf("fatal error: %s\n", e.what());
+        abort();
+    } catch (...) {
+        printf("fatal error: unknown exception type\n");
+        abort();
+    }
+}
+
+extern "C" sphericart_solid_harmonics_calculator_f_t* sphericart_solid_harmonics_new_f(size_t l_max) {
+    try {
+        return new sphericart::SolidHarmonics<float>(l_max);
+    } catch (...) {
+        // TODO: better error handling
+        return nullptr;
+    }
+}
+
+extern "C" void sphericart_solid_harmonics_delete_f(sphericart_solid_harmonics_calculator_f_t* calculator
+) {
+    try {
+        delete calculator;
+    } catch (...) {
+        // nothing to do
+    }
+}
+
+extern "C" void sphericart_solid_harmonics_compute_array_f(
+    sphericart_solid_harmonics_calculator_f_t* calculator,
+    const float* xyz,
+    size_t xyz_length,
+    float* sph,
+    size_t sph_length
+) {
+    try {
+        calculator->compute_array(xyz, xyz_length, sph, sph_length);
+    } catch (const std::exception& e) {
+        // TODO: better error handling
+        printf("fatal error: %s\n", e.what());
+        abort();
+    } catch (...) {
+        printf("fatal error: unknown exception type\n");
+        abort();
+    }
+}
+
+extern "C" void sphericart_solid_harmonics_compute_array_with_gradients_f(
+    sphericart_solid_harmonics_calculator_f_t* calculator,
+    const float* xyz,
+    size_t xyz_length,
+    float* sph,
+    size_t sph_length,
+    float* dsph,
+    size_t dsph_length
+) {
+    try {
+        calculator->compute_array_with_gradients(xyz, xyz_length, sph, sph_length, dsph, dsph_length);
+    } catch (const std::exception& e) {
+        // TODO: better error handling
+        printf("fatal error: %s\n", e.what());
+        abort();
+    } catch (...) {
+        printf("fatal error: unknown exception type\n");
+        abort();
+    }
+}
+
+extern "C" void sphericart_solid_harmonics_compute_array_with_hessians_f(
+    sphericart_solid_harmonics_calculator_f_t* calculator,
+    const float* xyz,
+    size_t xyz_length,
+    float* sph,
+    size_t sph_length,
+    float* dsph,
+    size_t dsph_length,
+    float* ddsph,
+    size_t ddsph_length
+) {
+    try {
+        calculator->compute_array_with_hessians(
+            xyz, xyz_length, sph, sph_length, dsph, dsph_length, ddsph, ddsph_length
+        );
+    } catch (const std::exception& e) {
+        // TODO: better error handling
+        printf("fatal error: %s\n", e.what());
+        abort();
+    } catch (...) {
+        printf("fatal error: unknown exception type\n");
+        abort();
+    }
+}
+
+extern "C" void sphericart_solid_harmonics_compute_sample_f(
+    sphericart_solid_harmonics_calculator_f_t* calculator,
+    const float* xyz,
+    size_t xyz_length,
+    float* sph,
+    size_t sph_length
+) {
+    try {
+        calculator->compute_sample(xyz, xyz_length, sph, sph_length);
+    } catch (const std::exception& e) {
+        // TODO: better error handling
+        printf("fatal error: %s\n", e.what());
+        abort();
+    } catch (...) {
+        printf("fatal error: unknown exception type\n");
+        abort();
+    }
+}
+
+extern "C" void sphericart_solid_harmonics_compute_sample_with_gradients_f(
+    sphericart_solid_harmonics_calculator_f_t* calculator,
+    const float* xyz,
+    size_t xyz_length,
+    float* sph,
+    size_t sph_length,
+    float* dsph,
+    size_t dsph_length
+) {
+    try {
+        calculator->compute_sample_with_gradients(
+            xyz, xyz_length, sph, sph_length, dsph, dsph_length
+        );
+    } catch (const std::exception& e) {
+        // TODO: better error handling
+        printf("fatal error: %s\n", e.what());
+        abort();
+    } catch (...) {
+        printf("fatal error: unknown exception type\n");
+        abort();
+    }
+}
+
+extern "C" void sphericart_solid_harmonics_compute_sample_with_hessians_f(
+    sphericart_solid_harmonics_calculator_f_t* calculator,
+    const float* xyz,
+    size_t xyz_length,
+    float* sph,
+    size_t sph_length,
+    float* dsph,
+    size_t dsph_length,
+    float* ddsph,
+    size_t ddsph_length
+) {
+    try {
+        calculator->compute_sample_with_hessians(
+            xyz, xyz_length, sph, sph_length, dsph, dsph_length, ddsph, ddsph_length
+        );
+    } catch (const std::exception& e) {
+        // TODO: better error handling
+        printf("fatal error: %s\n", e.what());
+        abort();
+    } catch (...) {
+        printf("fatal error: unknown exception type\n");
+        abort();
+    }
+}
+
+extern "C" int sphericart_solid_harmonics_omp_num_threads(
+    sphericart_solid_harmonics_calculator_t* calculator
+) {
+    return calculator->get_omp_num_threads();
+}
+
+extern "C" int sphericart_solid_harmonics_omp_num_threads_f(
+    sphericart_solid_harmonics_calculator_f_t* calculator
+) {
     return calculator->get_omp_num_threads();
 }

--- a/sphericart/src/sphericart.cpp
+++ b/sphericart/src/sphericart.cpp
@@ -382,10 +382,6 @@ void SphericalHarmonics<T>::compute_sample_with_hessians(
     );
 }
 
-// instantiates the SphericalHarmonics class for basic floating point types
-template class sphericart::SphericalHarmonics<float>;
-template class sphericart::SphericalHarmonics<double>;
-
 template <typename T>
 SolidHarmonics<T>::SolidHarmonics(size_t l_max) : SphericalHarmonics<T>(l_max) {
     /*
@@ -445,6 +441,9 @@ SolidHarmonics<T>::SolidHarmonics(size_t l_max) : SphericalHarmonics<T>(l_max) {
     }
 }
 
-// instantiates the SolidHarmonics class for basic floating point types
+// instantiates the SphericalHarmonics and SolidHarmonics classes
+// for basic floating point types
+template class sphericart::SphericalHarmonics<float>;
+template class sphericart::SphericalHarmonics<double>;
 template class sphericart::SolidHarmonics<float>;
 template class sphericart::SolidHarmonics<double>;

--- a/sphericart/src/sphericart.cpp
+++ b/sphericart/src/sphericart.cpp
@@ -9,20 +9,20 @@ using namespace sphericart;
 // This macro defines the different possible hardcoded function calls. It is
 // used to initialize the function pointers that are used by the `compute_`
 // calls in the SphericalHarmonics class
-#define _HARCODED_SWITCH_CASE(L_MAX)                                                               \
-    if (this->normalized) {                                                                        \
-        this->_array_no_derivatives = &hardcoded_sph<T, false, false, true, L_MAX>;                \
-        this->_array_with_derivatives = &hardcoded_sph<T, true, false, true, L_MAX>;               \
-        this->_sample_no_derivatives = &hardcoded_sph_sample<T, false, false, true, L_MAX>;        \
-        this->_sample_with_derivatives = &hardcoded_sph_sample<T, true, false, true, L_MAX>;       \
-    } else {                                                                                       \
-        this->_array_no_derivatives = &hardcoded_sph<T, false, false, false, L_MAX>;               \
-        this->_array_with_derivatives = &hardcoded_sph<T, true, false, false, L_MAX>;              \
-        this->_sample_no_derivatives = &hardcoded_sph_sample<T, false, false, false, L_MAX>;       \
-        this->_sample_with_derivatives = &hardcoded_sph_sample<T, true, false, false, L_MAX>;      \
-    }
+#define _HARDCODED_SWITCH_CASE_SPHERICAL_HARMONICS(L_MAX)                                          \
+    this->_array_no_derivatives = &hardcoded_sph<T, false, false, true, L_MAX>;                    \
+    this->_array_with_derivatives = &hardcoded_sph<T, true, false, true, L_MAX>;                   \
+    this->_sample_no_derivatives = &hardcoded_sph_sample<T, false, false, true, L_MAX>;            \
+    this->_sample_with_derivatives = &hardcoded_sph_sample<T, true, false, true, L_MAX>;
 
-template <typename T> SphericalHarmonics<T>::SphericalHarmonics(size_t l_max, bool normalized) {
+// Same, but for SolidHarmonics
+#define _HARDCODED_SWITCH_CASE_SOLID_HARMONICS(L_MAX)                                              \
+    this->_array_no_derivatives = &hardcoded_sph<T, false, false, false, L_MAX>;                   \
+    this->_array_with_derivatives = &hardcoded_sph<T, true, false, false, L_MAX>;                  \
+    this->_sample_no_derivatives = &hardcoded_sph_sample<T, false, false, false, L_MAX>;           \
+    this->_sample_with_derivatives = &hardcoded_sph_sample<T, true, false, false, L_MAX>;
+
+template <typename T> SphericalHarmonics<T>::SphericalHarmonics(size_t l_max) {
     /*
         This is the constructor of the SphericalHarmonics class. It initizlizes
        buffer space, compute prefactors, and sets the function pointers that are
@@ -32,7 +32,6 @@ template <typename T> SphericalHarmonics<T>::SphericalHarmonics(size_t l_max, bo
     this->l_max = (int)l_max;
     this->size_y = (int)(l_max + 1) * (l_max + 1);
     this->size_q = (int)(l_max + 1) * (l_max + 2) / 2;
-    this->normalized = normalized;
     this->prefactors = new T[this->size_q * 2];
     this->omp_num_threads = omp_get_max_threads();
 
@@ -48,76 +47,48 @@ template <typename T> SphericalHarmonics<T>::SphericalHarmonics(size_t l_max, bo
         // using a macro to avoid even more code duplication.
         switch (this->l_max) {
         case 0:
-            _HARCODED_SWITCH_CASE(0);
+            _HARDCODED_SWITCH_CASE_SPHERICAL_HARMONICS(0);
             break;
         case 1:
-            _HARCODED_SWITCH_CASE(1);
+            _HARDCODED_SWITCH_CASE_SPHERICAL_HARMONICS(1);
             break;
         case 2:
-            _HARCODED_SWITCH_CASE(2);
+            _HARDCODED_SWITCH_CASE_SPHERICAL_HARMONICS(2);
             break;
         case 3:
-            _HARCODED_SWITCH_CASE(3);
+            _HARDCODED_SWITCH_CASE_SPHERICAL_HARMONICS(3);
             break;
         case 4:
-            _HARCODED_SWITCH_CASE(4);
+            _HARDCODED_SWITCH_CASE_SPHERICAL_HARMONICS(4);
             break;
         case 5:
-            _HARCODED_SWITCH_CASE(5);
+            _HARDCODED_SWITCH_CASE_SPHERICAL_HARMONICS(5);
             break;
         case 6:
-            _HARCODED_SWITCH_CASE(6);
+            _HARDCODED_SWITCH_CASE_SPHERICAL_HARMONICS(6);
             break;
         }
     } else {
-        if (this->normalized) {
-            this->_array_no_derivatives =
-                &generic_sph<T, false, false, true, SPHERICART_LMAX_HARDCODED>;
-            this->_array_with_derivatives =
-                &generic_sph<T, true, false, true, SPHERICART_LMAX_HARDCODED>;
-            this->_sample_no_derivatives =
-                &generic_sph_sample<T, false, false, true, SPHERICART_LMAX_HARDCODED>;
-            this->_sample_with_derivatives =
-                &generic_sph_sample<T, true, false, true, SPHERICART_LMAX_HARDCODED>;
-        } else {
-            this->_array_no_derivatives =
-                &generic_sph<T, false, false, false, SPHERICART_LMAX_HARDCODED>;
-            this->_array_with_derivatives =
-                &generic_sph<T, true, false, false, SPHERICART_LMAX_HARDCODED>;
-            this->_sample_no_derivatives =
-                &generic_sph_sample<T, false, false, false, SPHERICART_LMAX_HARDCODED>;
-            this->_sample_with_derivatives =
-                &generic_sph_sample<T, true, false, false, SPHERICART_LMAX_HARDCODED>;
-        }
+        // if (this->normalized) {
+        this->_array_no_derivatives = &generic_sph<T, false, false, true, SPHERICART_LMAX_HARDCODED>;
+        this->_array_with_derivatives =
+            &generic_sph<T, true, false, true, SPHERICART_LMAX_HARDCODED>;
+        this->_sample_no_derivatives =
+            &generic_sph_sample<T, false, false, true, SPHERICART_LMAX_HARDCODED>;
+        this->_sample_with_derivatives =
+            &generic_sph_sample<T, true, false, true, SPHERICART_LMAX_HARDCODED>;
     }
 
     // set up the second derivative functions
-    if (this->normalized) {
-        if (this->l_max == 0) {
-            this->_array_with_hessians = &hardcoded_sph<T, true, true, true, 0>;
-            this->_sample_with_hessians = &hardcoded_sph_sample<T, true, true, true, 0>;
-        } else if (this->l_max == 1) {
-            this->_array_with_hessians = &hardcoded_sph<T, true, true, true, 1>;
-            this->_sample_with_hessians = &hardcoded_sph_sample<T, true, true, true, 1>;
-        } else { // second derivatives are not hardcoded past l = 1. Call
-                 // generic
-            // implementations
-            this->_array_with_hessians = &generic_sph<T, true, true, true, 1>;
-            this->_sample_with_hessians = &generic_sph_sample<T, true, true, true, 1>;
-        }
-    } else {
-        if (this->l_max == 0) {
-            this->_array_with_hessians = &hardcoded_sph<T, true, true, false, 0>;
-            this->_sample_with_hessians = &hardcoded_sph_sample<T, true, true, false, 0>;
-        } else if (this->l_max == 1) {
-            this->_array_with_hessians = &hardcoded_sph<T, true, true, false, 1>;
-            this->_sample_with_hessians = &hardcoded_sph_sample<T, true, true, false, 1>;
-        } else { // second derivatives are not hardcoded past l = 1. Call
-                 // generic
-            // implementations
-            this->_array_with_hessians = &generic_sph<T, true, true, false, 1>;
-            this->_sample_with_hessians = &generic_sph_sample<T, true, true, false, 1>;
-        }
+    if (this->l_max == 0) {
+        this->_array_with_hessians = &hardcoded_sph<T, true, true, true, 0>;
+        this->_sample_with_hessians = &hardcoded_sph_sample<T, true, true, true, 0>;
+    } else if (this->l_max == 1) {
+        this->_array_with_hessians = &hardcoded_sph<T, true, true, true, 1>;
+        this->_sample_with_hessians = &hardcoded_sph_sample<T, true, true, true, 1>;
+    } else { // second derivatives are not hardcoded past l = 1. Call generic implementations
+        this->_array_with_hessians = &generic_sph<T, true, true, true, 1>;
+        this->_sample_with_hessians = &generic_sph_sample<T, true, true, true, 1>;
     }
 }
 
@@ -414,3 +385,66 @@ void SphericalHarmonics<T>::compute_sample_with_hessians(
 // instantiates the SphericalHarmonics class for basic floating point types
 template class sphericart::SphericalHarmonics<float>;
 template class sphericart::SphericalHarmonics<double>;
+
+template <typename T>
+SolidHarmonics<T>::SolidHarmonics(size_t l_max) : SphericalHarmonics<T>(l_max) {
+    /*
+        This is the constructor of the SolidHarmonics class. It initizlizes
+       buffer space, compute prefactors, and sets the function pointers that are
+       used for the actual calls
+    */
+
+    // Just override the function pointers with the SolidHarmonics versions
+    if (this->l_max <= SPHERICART_LMAX_HARDCODED) {
+        // If we only need hard-coded calls, we set them up at this point
+        // using a macro to avoid even more code duplication.
+        switch (this->l_max) {
+        case 0:
+            _HARDCODED_SWITCH_CASE_SOLID_HARMONICS(0);
+            break;
+        case 1:
+            _HARDCODED_SWITCH_CASE_SOLID_HARMONICS(1);
+            break;
+        case 2:
+            _HARDCODED_SWITCH_CASE_SOLID_HARMONICS(2);
+            break;
+        case 3:
+            _HARDCODED_SWITCH_CASE_SOLID_HARMONICS(3);
+            break;
+        case 4:
+            _HARDCODED_SWITCH_CASE_SOLID_HARMONICS(4);
+            break;
+        case 5:
+            _HARDCODED_SWITCH_CASE_SOLID_HARMONICS(5);
+            break;
+        case 6:
+            _HARDCODED_SWITCH_CASE_SOLID_HARMONICS(6);
+            break;
+        }
+    } else {
+        this->_array_no_derivatives =
+            &generic_sph<T, false, false, false, SPHERICART_LMAX_HARDCODED>;
+        this->_array_with_derivatives =
+            &generic_sph<T, true, false, false, SPHERICART_LMAX_HARDCODED>;
+        this->_sample_no_derivatives =
+            &generic_sph_sample<T, false, false, false, SPHERICART_LMAX_HARDCODED>;
+        this->_sample_with_derivatives =
+            &generic_sph_sample<T, true, false, false, SPHERICART_LMAX_HARDCODED>;
+    }
+
+    // set up the second derivative functions
+    if (this->l_max == 0) {
+        this->_array_with_hessians = &hardcoded_sph<T, true, true, false, 0>;
+        this->_sample_with_hessians = &hardcoded_sph_sample<T, true, true, false, 0>;
+    } else if (this->l_max == 1) {
+        this->_array_with_hessians = &hardcoded_sph<T, true, true, false, 1>;
+        this->_sample_with_hessians = &hardcoded_sph_sample<T, true, true, false, 1>;
+    } else { // second derivatives are not hardcoded past l = 1. Call generic implementations
+        this->_array_with_hessians = &generic_sph<T, true, true, false, 1>;
+        this->_sample_with_hessians = &generic_sph_sample<T, true, true, false, 1>;
+    }
+}
+
+// instantiates the SolidHarmonics class for basic floating point types
+template class sphericart::SolidHarmonics<float>;
+template class sphericart::SolidHarmonics<double>;

--- a/sphericart/src/sphericart_cuda.cu
+++ b/sphericart/src/sphericart_cuda.cu
@@ -24,7 +24,7 @@ using namespace sphericart::cuda;
         }                                                                                          \
     } while (0)
 
-template <typename T> SphericalHarmonics<T>::SphericalHarmonics(size_t l_max, bool normalized) {
+template <typename T> SphericalHarmonics<T>::SphericalHarmonics(size_t l_max) {
     /*
         This is the constructor of the SphericalHarmonics class. It initizlizes
        buffer space, compute prefactors, and sets the function pointers that are
@@ -32,7 +32,7 @@ template <typename T> SphericalHarmonics<T>::SphericalHarmonics(size_t l_max, bo
     */
     this->l_max = (int)l_max;
     this->nprefactors = (int)(l_max + 1) * (l_max + 2);
-    this->normalized = normalized;
+    this->normalized = true; // SphericalHarmonics class
     this->prefactors_cpu = new T[this->nprefactors];
 
     CUDA_CHECK(cudaGetDeviceCount(&this->device_count));
@@ -211,6 +211,14 @@ void SphericalHarmonics<T>::compute(
     CUDA_CHECK(cudaSetDevice(current_device));
 }
 
-// instantiates the SphericalHarmonics class for basic floating point types
+template <typename T>
+SolidHarmonics<T>::SolidHarmonics(size_t l_max) : SphericalHarmonics<T>(l_max) {
+    this->normalized = false; // SolidHarmonics class
+}
+
+// instantiates the SphericalHarmonics and SolidHarmonics classes
+// for basic floating point types
 template class sphericart::cuda::SphericalHarmonics<float>;
 template class sphericart::cuda::SphericalHarmonics<double>;
+template class sphericart::cuda::SolidHarmonics<float>;
+template class sphericart::cuda::SolidHarmonics<double>;

--- a/sphericart/src/sphericart_cuda_stub.cpp
+++ b/sphericart/src/sphericart_cuda_stub.cpp
@@ -4,8 +4,7 @@
 
 using namespace sphericart::cuda;
 
-template <typename T>
-SphericalHarmonics<T>::SphericalHarmonics(size_t /*l_max*/, bool /*normalized*/) {}
+template <typename T> SphericalHarmonics<T>::SphericalHarmonics(size_t /*l_max*/) {}
 
 template <typename T> SphericalHarmonics<T>::~SphericalHarmonics() {}
 
@@ -23,6 +22,12 @@ void SphericalHarmonics<T>::compute(
     throw std::runtime_error("sphericart was not compiled with CUDA support");
 }
 
-// instantiates the SphericalHarmonics class for basic floating point types
+template <typename T>
+SolidHarmonics<T>::SolidHarmonics(size_t l_max) : SphericalHarmonics<T>(l_max) {}
+
+// instantiates the SphericalHarmonics and SolidHarmonics classes
+// for basic floating point types
 template class sphericart::cuda::SphericalHarmonics<float>;
 template class sphericart::cuda::SphericalHarmonics<double>;
+template class sphericart::cuda::SolidHarmonics<float>;
+template class sphericart::cuda::SolidHarmonics<double>;

--- a/sphericart/tests/test_derivatives.cpp
+++ b/sphericart/tests/test_derivatives.cpp
@@ -177,26 +177,27 @@ int main() {
     }
 
     for (int l_max = 0; l_max < l_max_max; l_max++) { // Test for a range of l_max values
-        sphericart::SphericalHarmonics<double> calculator =
+        sphericart::SphericalHarmonics<double> calculator_spherical =
             sphericart::SphericalHarmonics<double>(l_max);
-        is_passed = check_gradient_call(l_max, calculator, xyz);
+        is_passed = check_gradient_call(l_max, calculator_spherical, xyz);
         if (!is_passed) {
             std::cout << "Test failed" << std::endl;
             return -1;
         }
-        is_passed = check_hessian_call(l_max, calculator, xyz);
+        is_passed = check_hessian_call(l_max, calculator_spherical, xyz);
         if (!is_passed) {
             std::cout << "Test failed" << std::endl;
             return -1;
         }
 
-        sphericart::SolidHarmonics<double> calculator = sphericart::SolidHarmonics<double>(l_max);
-        is_passed = check_gradient_call(l_max, calculator, xyz);
+        sphericart::SolidHarmonics<double> calculator_solid =
+            sphericart::SolidHarmonics<double>(l_max);
+        is_passed = check_gradient_call(l_max, calculator_solid, xyz);
         if (!is_passed) {
             std::cout << "Test failed" << std::endl;
             return -1;
         }
-        is_passed = check_hessian_call(l_max, calculator, xyz);
+        is_passed = check_hessian_call(l_max, calculator_solid, xyz);
         if (!is_passed) {
             std::cout << "Test failed" << std::endl;
             return -1;

--- a/sphericart/tests/test_derivatives.cpp
+++ b/sphericart/tests/test_derivatives.cpp
@@ -13,9 +13,8 @@
     1e-4 // High tolerance: finite differences are inaccurate for second
          // derivatives
 
-bool check_gradient_call(
-    int l_max, sphericart::SphericalHarmonics<double>& calculator, const std::vector<double>& xyz
-) {
+template <template <typename> class C>
+bool check_gradient_call(int l_max, C<double>& calculator, const std::vector<double>& xyz) {
     bool is_passed = true;
     int n_samples = xyz.size() / 3;
     int n_sph = (l_max + 1) * (l_max + 1);
@@ -60,9 +59,8 @@ bool check_gradient_call(
     return is_passed;
 }
 
-bool check_hessian_call(
-    int l_max, sphericart::SphericalHarmonics<double>& calculator, const std::vector<double>& xyz
-) {
+template <template <typename> class C>
+bool check_hessian_call(int l_max, C<double>& calculator, const std::vector<double>& xyz) {
     bool is_passed = true;
     int n_samples = xyz.size() / 3;
     int n_sph = (l_max + 1) * (l_max + 1);
@@ -178,20 +176,30 @@ int main() {
         }
     }
 
-    for (bool normalize : {false, true}) {                // Test with and without normalization
-        for (int l_max = 0; l_max < l_max_max; l_max++) { // Test for a range of l_max values
-            sphericart::SphericalHarmonics<double> normalized_calculator =
-                sphericart::SphericalHarmonics<double>(l_max, normalize);
-            is_passed = check_gradient_call(l_max, normalized_calculator, xyz);
-            if (!is_passed) {
-                std::cout << "Test failed" << std::endl;
-                return -1;
-            }
-            is_passed = check_hessian_call(l_max, normalized_calculator, xyz);
-            if (!is_passed) {
-                std::cout << "Test failed" << std::endl;
-                return -1;
-            }
+    for (int l_max = 0; l_max < l_max_max; l_max++) { // Test for a range of l_max values
+        sphericart::SphericalHarmonics<double> calculator =
+            sphericart::SphericalHarmonics<double>(l_max);
+        is_passed = check_gradient_call(l_max, calculator, xyz);
+        if (!is_passed) {
+            std::cout << "Test failed" << std::endl;
+            return -1;
+        }
+        is_passed = check_hessian_call(l_max, calculator, xyz);
+        if (!is_passed) {
+            std::cout << "Test failed" << std::endl;
+            return -1;
+        }
+
+        sphericart::SolidHarmonics<double> calculator = sphericart::SolidHarmonics<double>(l_max);
+        is_passed = check_gradient_call(l_max, calculator, xyz);
+        if (!is_passed) {
+            std::cout << "Test failed" << std::endl;
+            return -1;
+        }
+        is_passed = check_hessian_call(l_max, calculator, xyz);
+        if (!is_passed) {
+            std::cout << "Test failed" << std::endl;
+            return -1;
         }
     }
 

--- a/sphericart/tests/test_hardcoding.cpp
+++ b/sphericart/tests/test_hardcoding.cpp
@@ -78,7 +78,7 @@ int main(int argc, char* argv[]) {
     auto sph1 = std::vector<DTYPE>(n_samples * (l_max + 1) * (l_max + 1), 0.0);
     auto dsph1 = std::vector<DTYPE>(n_samples * 3 * (l_max + 1) * (l_max + 1), 0.0);
 
-    SphericalHarmonics<DTYPE> SH(l_max, false);
+    SphericalHarmonics<DTYPE> SH(l_max);
     SH.compute_with_gradients(xyz, sph1, dsph1);
 
     int size3 = 3 * (l_max + 1) * (l_max + 1); // Size of the third dimension in derivative

--- a/sphericart/tests/test_hardcoding.cpp
+++ b/sphericart/tests/test_hardcoding.cpp
@@ -78,7 +78,7 @@ int main(int argc, char* argv[]) {
     auto sph1 = std::vector<DTYPE>(n_samples * (l_max + 1) * (l_max + 1), 0.0);
     auto dsph1 = std::vector<DTYPE>(n_samples * 3 * (l_max + 1) * (l_max + 1), 0.0);
 
-    SphericalHarmonics<DTYPE> SH(l_max);
+    SolidHarmonics<DTYPE> SH(l_max);
     SH.compute_with_gradients(xyz, sph1, dsph1);
 
     int size3 = 3 * (l_max + 1) * (l_max + 1); // Size of the third dimension in derivative

--- a/sphericart/tests/test_samples.cpp
+++ b/sphericart/tests/test_samples.cpp
@@ -34,7 +34,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char* argv[]) {
         auto dsph = std::vector<DTYPE>(n_samples * 3 * (l_max + 1) * (l_max + 1), 0.0);
         auto sph_sample = std::vector<DTYPE>(1 * (l_max + 1) * (l_max + 1), 0.0);
         auto dsph_sample = std::vector<DTYPE>(1 * 3 * (l_max + 1) * (l_max + 1), 0.0);
-        SphericalHarmonics<DTYPE> SH(l_max, false);
+        SphericalHarmonics<DTYPE> SH(l_max);
         SH.compute_with_gradients(xyz_sample, sph_sample, dsph_sample);
         SH.compute_with_gradients(xyz, sph, dsph);
         int size3 = 3 * (l_max + 1) * (l_max + 1); // Size of the third dimension in derivative

--- a/tox.ini
+++ b/tox.ini
@@ -57,8 +57,8 @@ passenv=
     PIP_EXTRA_INDEX_URL
 commands =
     pip install {[testenv]pip_install_flags} .
+    pytest python
 
-    ; pytest python
 
 [testenv:jax-tests]
 # this environement runs tests for the jax bindings
@@ -86,8 +86,8 @@ commands =
     bash -c "command -v nvcc && python -m pip install -U jax[cuda12] -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html || python -m pip install -U jax[cpu]"
 
     pip install {[testenv]pip_install_flags} .
-
     pytest python
+
 
 [testenv:examples]
 # this environement runs the examples for Python and Pytorch bindings
@@ -110,7 +110,7 @@ commands =
     pip install {[testenv]pip_install_flags} ./sphericart-jax
 
     python examples/python/example.py
-    ; python examples/pytorch/example.py
+    python examples/pytorch/example.py
     python examples/jax/example.py
 
     python examples/python/spherical.py

--- a/tox.ini
+++ b/tox.ini
@@ -58,7 +58,7 @@ passenv=
 commands =
     pip install {[testenv]pip_install_flags} .
 
-    pytest python
+    ; pytest python
 
 [testenv:jax-tests]
 # this environement runs tests for the jax bindings
@@ -110,7 +110,7 @@ commands =
     pip install {[testenv]pip_install_flags} ./sphericart-jax
 
     python examples/python/example.py
-    python examples/pytorch/example.py
+    ; python examples/pytorch/example.py
     python examples/jax/example.py
 
     python examples/python/spherical.py


### PR DESCRIPTION
This is much more intuitive for the user (at the moment, if they ask for the spherical harmonics, they get something else by default), matches the Julia API, and also seems to be accepted in the field (see e3x API for spherical and solid harmonics)