### PR TITLE
Stop pinning numpy to <2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "sphericart"
 dynamic = ["version", "optional-dependencies"]
 requires-python = ">=3.8"
-dependencies = ["numpy<2.0.0"]
+dependencies = ["numpy"]
 
 readme = "README.md"
 license = {text = "Apache-2.0 or MIT"}

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ deps =
     setuptools
     cmake
 
-    numpy<2.0.0
+    numpy
     scipy
     pytest
 
@@ -46,7 +46,7 @@ deps =
     setuptools
     cmake
 
-    numpy<2.0.0
+    numpy
     torch
     pytest
 
@@ -68,7 +68,7 @@ deps =
     cmake
     pybind11
 
-    numpy<2.0.0
+    numpy
     absl-py # jax uses this package but not installed by jax[cpu]
     pytest
     equinox
@@ -97,7 +97,7 @@ deps =
     cmake
     pybind11
 
-    numpy<2.0.0
+    numpy
     torch
     pytest
 


### PR DESCRIPTION
We should no longer need this.