### PR TITLE
Dynamically load `c10::cuda::getCurrentCUDAStream` in sphericart-torch

### DIFF
--- a/scripts/check-format.sh
+++ b/scripts/check-format.sh
@@ -5,12 +5,4 @@ set -eu
 ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)
 cd "$ROOT_DIR"
 
-find . -type f \(                            \
-        -name "*.c" -o -name "*.cpp"         \
-        -o -name "*.h" -o -name "*.hpp"      \
-        -o -name "*.cu" -o -name "*.cuh"     \
-    \)                                       \
-    -not -path "*/external/*"                \
-    -not -path "*/build/*"                   \
-    -not -path "*/.tox/*"                    \
-    -exec clang-format --dry-run --Werror {} \;
+git ls-files '*.cpp' '*.c' '*.hpp' '*.h' '*.cu' '*.cuh' | xargs -L 1 clang-format --dry-run --Werror

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -5,12 +5,4 @@ set -eu
 ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)
 cd "$ROOT_DIR"
 
-find . -type f \(                            \
-        -name "*.c" -o -name "*.cpp"         \
-        -o -name "*.h" -o -name "*.hpp"      \
-        -o -name "*.cu" -o -name "*.cuh"     \
-    \)                                       \
-    -not -path "*/external/*"                \
-    -not -path "*/build/*"                   \
-    -not -path "*/.tox/*"                    \
-    -exec clang-format -i {} \;
+git ls-files '*.cpp' '*.c' '*.hpp' '*.h' '*.cu' '*.cuh' | xargs -L 1 clang-format -i

--- a/sphericart-torch/CMakeLists.txt
+++ b/sphericart-torch/CMakeLists.txt
@@ -122,17 +122,16 @@ else()
     target_sources(sphericart_torch PUBLIC "src/torch_cuda_wrapper_stub.cpp")
 endif()
 
-target_link_libraries(sphericart_torch PUBLIC torch sphericart)
+target_link_libraries(sphericart_torch PUBLIC sphericart)
+
+# only link to `torch_cpu_library` instead of `torch`, which could also include
+# `libtorch_cuda`.
+target_link_libraries(sphericart_torch PUBLIC torch_cpu_library)
+target_include_directories(sphericart_torch PUBLIC "${TORCH_INCLUDE_DIRS}")
+target_compile_definitions(sphericart_torch PUBLIC "${TORCH_CXX_FLAGS}")
+
 if(OpenMP_CXX_FOUND)
     target_link_libraries(sphericart_torch PUBLIC OpenMP::OpenMP_CXX)
-endif()
-
-message (STATUS "CUDA Toolkit Dir: ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}")
-
-if(CMAKE_CUDA_COMPILER)
-    target_compile_definitions(sphericart_torch PRIVATE CUDA_AVAILABLE)
-    target_compile_definitions(sphericart_torch PRIVATE C10_CUDA_NO_CMAKE_CONFIGURE_FILE)
-    target_include_directories(sphericart_torch PRIVATE ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
 endif()
 
 target_compile_features(sphericart_torch PUBLIC cxx_std_17)
@@ -142,7 +141,29 @@ target_include_directories(sphericart_torch PUBLIC
     $<INSTALL_INTERFACE:include>
 )
 
+if (LINUX)
+    # so dlopen can find libsphericart_torch_cuda_stream.so
+    set_target_properties(sphericart_torch PROPERTIES INSTALL_RPATH "$ORIGIN")
+endif()
+
+add_library(sphericart_torch_cuda_stream SHARED
+    "src/streams.cpp"
+)
+target_link_libraries(sphericart_torch_cuda_stream PUBLIC torch)
+target_compile_features(sphericart_torch_cuda_stream PUBLIC cxx_std_17)
+
+if(CMAKE_CUDA_COMPILER)
+    target_compile_definitions(sphericart_torch_cuda_stream PRIVATE CUDA_AVAILABLE)
+    target_compile_definitions(sphericart_torch_cuda_stream PRIVATE C10_CUDA_NO_CMAKE_CONFIGURE_FILE)
+    target_include_directories(sphericart_torch_cuda_stream PRIVATE ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
+endif()
+
+
 install(TARGETS sphericart_torch
+    LIBRARY DESTINATION "lib"
+)
+
+install(TARGETS sphericart_torch_cuda_stream
     LIBRARY DESTINATION "lib"
 )
 

--- a/sphericart-torch/src/streams.cpp
+++ b/sphericart-torch/src/streams.cpp
@@ -1,0 +1,27 @@
+#include <cstdint>
+
+#include <torch/torch.h>
+
+#ifdef CUDA_AVAILABLE
+#include <c10/cuda/CUDAStream.h>
+
+// This function re-expose `c10::cuda::getCurrentCUDAStream` in a way we can
+// call through dlopen/dlsym, and is intended to be compiled in a separate
+// shared library from the main sphericart_torch one.
+//
+// The alternative would be to link the main library directly to
+// `libtorch_cuda`, but doing so will prevent users from loading
+// sphericart_torch when using a CPU-only version of torch.
+extern "C" void* get_current_cuda_stream(uint8_t device_id) {
+    return reinterpret_cast<void*>(c10::cuda::getCurrentCUDAStream(device_id).stream());
+}
+
+#else
+
+extern "C" void* get_current_cuda_stream(uint8_t device_id) {
+    TORCH_WARN_ONCE("Something wrong is happening: trying to get the current CUDA stream, "
+                    "but this version of sphericart was compiled without CUDA support");
+    return nullptr;
+}
+
+#endif

--- a/sphericart-torch/src/torch_cuda_wrapper.cpp
+++ b/sphericart-torch/src/torch_cuda_wrapper.cpp
@@ -1,7 +1,4 @@
 #include "sphericart/torch_cuda_wrapper.hpp"
-#include <cuda.h>
-#include <cuda_runtime.h>
-#include <iostream>
 #include <torch/torch.h>
 
 #define _SPHERICART_INTERNAL_IMPLEMENTATION // gives us access to

--- a/sphericart/CMakeLists.txt
+++ b/sphericart/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.27)
 project(sphericart LANGUAGES C CXX)
 
 #[[
- This function wraps the input file with the appropriate string to allow us to 
+ This function wraps the input file with the appropriate string to allow us to
  static-initialize string variables, for example:
      static const char* CUDA_CODE =
 #include "generated/wrapped_sphericart_impl.cu"
@@ -128,7 +128,7 @@ if (CMAKE_CUDA_COMPILER AND SPHERICART_ENABLE_CUDA)
     # Prepend headers to the source file
     prepend_headers_to_source(
         "${CMAKE_CURRENT_SOURCE_DIR}/src/sphericart_impl.cu"
-        "${CMAKE_CURRENT_BINARY_DIR}/generated/tmp.cu" 
+        "${CMAKE_CURRENT_BINARY_DIR}/generated/tmp.cu"
         "${SPHERICART_CUDA_HEADERS}"
         )
 


### PR DESCRIPTION
This should enable using the pre-built wheels with a CPU-only version of torch, by moving the dependency on `libtorch_cuda` from `sphericart_torch` to `sphericart_torch_cuda_stream`