### PR TITLE
Allow FloatX for arbitary X

### DIFF
--- a/julia/Project.toml
+++ b/julia/Project.toml
@@ -8,16 +8,18 @@ Bumper = "8ce10254-0962-460f-a3d8-1f77fea1446e"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
+Quadmath = "be4d8f0f-7fa4-5f49-b795-2f01399ab2dd"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 StrideArrays = "d1fa6d79-ef01-42a6-86c9-f7c551f8593b"
 
 [compat]
 Bumper = "0.6.0, 0.7.0"
-StrideArrays = "0.1.28"
 ForwardDiff = "0.10"
 LinearAlgebra = "1.8"
 OffsetArrays = "1.13"
+Quadmath = "0.5.11"
 StaticArrays = "1.9"
+StrideArrays = "0.1.28"
 julia = "1.8.0, 1.9.0, 1.10.0"
 
 [extras]

--- a/julia/src/normalisations.jl
+++ b/julia/src/normalisations.jl
@@ -4,7 +4,7 @@
 # Generates the `F[l, m]` values exactly as described in the 
 # `sphericart` publication.  This gives L2-orthonormality. 
 function _generate_Flms(L::Integer, ::Union{Val{:sphericart}, Val{:L2}}, T=Float64)
-   Flm = OffsetMatrix(zeros(L+1, L+1), (-1, -1))
+   Flm = OffsetMatrix(zeros(T, L+1, L+1), (-1, -1))
    for l = 0:L
       Flm[l, 0] = sqrt((2*l+1)/(2 * π))
       for m = 1:l 

--- a/julia/test/test_f32.jl
+++ b/julia/test/test_f32.jl
@@ -1,17 +1,75 @@
-using SpheriCart, StaticArrays, LinearAlgebra
+using SpheriCart, StaticArrays, LinearAlgebra, Quadmath, Printf 
+
+
+##
 
 n_samples = 100_000 
+Rs = [ @SVector randn(3) for _ = 1:n_samples ]
 
-for L = 4:2:12
+@printf("  L  |  |Z32-Z64|  |Z64-Z128|  |   |∇Z32-∇Z64|  |∇Z64-∇Z128|  \n")
+@printf("-----|-------------------------|----------------------------- \n")
+
+for L = 4:4:20
    basis = SolidHarmonics(L; static=false)
-   Rs = [ @SVector randn(3) for _ = 1:n_samples ]
-   Z = compute(basis, Rs)
+   
+   Z, ∇Z = compute_with_gradients(basis, Rs)
 
    basis_f32 = SolidHarmonics(L; static=false, T = Float32)
    Rs_f32 = [ Float32.(𝐫) for 𝐫 in Rs]
-   Z_f32 = compute(basis_f32, Rs_f32)
+   Z_f32, ∇Z_f32 = compute_with_gradients(basis_f32, Rs_f32)
 
-   @info(L)
-   @show norm(Z - Z_f32, Inf)
-   @show norm((Z - Z_f32) ./ (1 .+ abs.(Z)), Inf)
+   basis_quad = SolidHarmonics(L; static=false, T = Float128)
+   Rs_quad = [ Float128.(𝐫) for 𝐫 in Rs]
+   Z_quad, ∇Z_quad = compute_with_gradients(basis_quad, Rs_quad)
+
+   @printf("  %2d |  %.2e    %.2e   |   %.2e     %.2e  \n", 
+            L, 
+            norm(Z - Z_f32, Inf), 
+            norm(Z_f32 - Z_quad, Inf), 
+            norm(∇Z - ∇Z_f32, Inf), 
+            norm(∇Z_f32 - ∇Z_quad, Inf) )
+end
+
+## 
+
+function compute_Q(L, Rs64, T)
+   Rs = [ T.(𝐫) for 𝐫 in Rs64 ]
+   basis = SolidHarmonics(L; static=false, T = T)
+   nX = length(Rs)
+   len = SpheriCart.sizeY(L)
+   Z = zeros(T, nX, len)
+   # ∇Z = zeros(SVector{3, T}, nX, len)
+   
+   # allocate temporary arrays from an array cache 
+   temps = (x = zeros(T, nX), 
+            y = zeros(T, nX),
+            z = zeros(T, nX), 
+           r² = zeros(T, nX),
+            s = zeros(T, nX, L+1), 
+            c = zeros(T, nX, L+1),
+            Q = zeros(T, nX, SpheriCart.sizeY(L)),
+          Flm = basis.Flm )
+
+   SpheriCart.solid_harmonics!(Z, Val{L}(), Rs, temps)          
+             
+   return temps.Q 
+end
+
+
+##
+
+# n_samples = 100_000 
+# Rs = [ @SVector randn(3) for _ = 1:n_samples ]
+
+@printf("  L   |Q32-Q64|  |Q64-Q128| \n")
+@printf("----------------------------\n")
+for L = 4:4:20
+   Q_32 = compute_Q(L, Rs, Float32)
+   Q_64 = compute_Q(L, Rs, Float64)
+   Q_128 = compute_Q(L, Rs, Float128)
+
+   @printf(" %2d   %.2e   %.2e \n", 
+            L, 
+            norm(Q_32 - Q_64, Inf), 
+            norm(Q_64 - Q_128, Inf) )
 end

--- a/julia/test/test_f32.jl
+++ b/julia/test/test_f32.jl
@@ -1,0 +1,17 @@
+using SpheriCart, StaticArrays, LinearAlgebra
+
+n_samples = 100_000 
+
+for L = 4:2:12
+   basis = SolidHarmonics(L; static=false)
+   Rs = [ @SVector randn(3) for _ = 1:n_samples ]
+   Z = compute(basis, Rs)
+
+   basis_f32 = SolidHarmonics(L; static=false, T = Float32)
+   Rs_f32 = [ Float32.(𝐫) for 𝐫 in Rs]
+   Z_f32 = compute(basis_f32, Rs_f32)
+
+   @info(L)
+   @show norm(Z - Z_f32, Inf)
+   @show norm((Z - Z_f32) ./ (1 .+ abs.(Z)), Inf)
+end

--- a/julia/test/test_f32.jl
+++ b/julia/test/test_f32.jl
@@ -1,44 +1,52 @@
-using SpheriCart, StaticArrays, LinearAlgebra, Quadmath, Printf 
+using SpheriCart, StaticArrays, LinearAlgebra, Quadmath, Printf, Test
 
 
 ##
 
-n_samples = 100_000 
+n_samples = 10_000 
 Rs = [ @SVector randn(3) for _ = 1:n_samples ]
+Rs_64 = [ 𝐫/norm(𝐫) for 𝐫 in Rs ]
+Rs_32 = [ Float32.(𝐫) for 𝐫 in Rs_64 ]
+Rs_128 = [ Float128.(𝐫) for 𝐫 in Rs_64 ]
+
+tol_32 = eps(Float32) * 1e2 
+tol_64 = eps(Float64) * 1e2
 
 @printf("  L  |  |Z32-Z64|  |Z64-Z128|  |   |∇Z32-∇Z64|  |∇Z64-∇Z128|  \n")
 @printf("-----|-------------------------|----------------------------- \n")
 
 for L = 4:4:20
-   basis = SolidHarmonics(L; static=false)
-   
-   Z, ∇Z = compute_with_gradients(basis, Rs)
+   basis_64 = SolidHarmonics(L; static=false)
+   Z_64, ∇Z_64 = compute_with_gradients(basis_64, Rs_64)
 
-   basis_f32 = SolidHarmonics(L; static=false, T = Float32)
-   Rs_f32 = [ Float32.(𝐫) for 𝐫 in Rs]
-   Z_f32, ∇Z_f32 = compute_with_gradients(basis_f32, Rs_f32)
+   basis_32 = SolidHarmonics(L; static=false, T = Float32)
+   Z_32, ∇Z_32 = compute_with_gradients(basis_32, Rs_32)
 
-   basis_quad = SolidHarmonics(L; static=false, T = Float128)
-   Rs_quad = [ Float128.(𝐫) for 𝐫 in Rs]
-   Z_quad, ∇Z_quad = compute_with_gradients(basis_quad, Rs_quad)
+   basis_128 = SolidHarmonics(L; static=false, T = Float128)
+   Z_128, ∇Z_128 = compute_with_gradients(basis_128, Rs_128)
+
+   err_32 = norm(Z_64 - Z_32, Inf)
+   err_64 = norm(Z_64 - Z_128, Inf)
+   ∇err_32 = norm(∇Z_64 - ∇Z_32, Inf)
+   ∇err_64 = norm(∇Z_64 - ∇Z_128, Inf)
 
    @printf("  %2d |  %.2e    %.2e   |   %.2e     %.2e  \n", 
-            L, 
-            norm(Z - Z_f32, Inf), 
-            norm(Z_f32 - Z_quad, Inf), 
-            norm(∇Z - ∇Z_f32, Inf), 
-            norm(∇Z_f32 - ∇Z_quad, Inf) )
+            L, err_32, err_64, ∇err_32, ∇err_64)
+
+   @test err_32 / L^2 < tol_32
+   @test err_64 / L^2 < tol_64
+   @test ∇err_32 / L^2 < tol_32
+   @test ∇err_64 / L^2 < tol_64
 end
+println()
 
 ## 
 
-function compute_Q(L, Rs64, T)
-   Rs = [ T.(𝐫) for 𝐫 in Rs64 ]
+function compute_Q(L, Rs::Vector{SVector{3, T}}) where {T} 
    basis = SolidHarmonics(L; static=false, T = T)
    nX = length(Rs)
    len = SpheriCart.sizeY(L)
    Z = zeros(T, nX, len)
-   # ∇Z = zeros(SVector{3, T}, nX, len)
    
    # allocate temporary arrays from an array cache 
    temps = (x = zeros(T, nX), 
@@ -58,18 +66,20 @@ end
 
 ##
 
-# n_samples = 100_000 
-# Rs = [ @SVector randn(3) for _ = 1:n_samples ]
+# Relative errors for Q 
 
-@printf("  L   |Q32-Q64|  |Q64-Q128| \n")
-@printf("----------------------------\n")
-for L = 4:4:20
-   Q_32 = compute_Q(L, Rs, Float32)
-   Q_64 = compute_Q(L, Rs, Float64)
-   Q_128 = compute_Q(L, Rs, Float128)
+# @printf("  L   |Q32-Q64|  |Q64-Q128| \n")
+# @printf("----------------------------\n")
+# for L = 4:4:20
+#    Q_32  = compute_Q(L, Rs_32)
+#    Q_64  = compute_Q(L, Rs_64)
+#    Q_128 = compute_Q(L, Rs_128)
 
-   @printf(" %2d   %.2e   %.2e \n", 
-            L, 
-            norm(Q_32 - Q_64, Inf), 
-            norm(Q_64 - Q_128, Inf) )
-end
+#    err_32 = norm(Q_32 - Q_64, Inf) / (1+norm(Q_64, Inf))
+#    err_64 = norm(Q_64 - Q_128, Inf) / (1+norm(Q_128, Inf))
+
+#    @printf(" %2d   %.2e   %.2e \n",  L, err_32, err_64)
+
+#    # @test err_32 / L^2 < tol_32
+#    # @test err_64 / L^2 < tol_64
+# end


### PR DESCRIPTION
There was a bug in the basis construction, now FloatX for arbitrary X should work, added tests for Float32 and Float128. (also good to test for numerical stability)