### PR TITLE
Upgrade tests to Ubuntu 22.04

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   build-and-publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: setup Python

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
           - os: macos-14
     steps:
       - uses: actions/checkout@v3
@@ -63,7 +63,7 @@ jobs:
 
   # check that we can build Python wheels on any Python version
   python-build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: check Python build
     strategy:
       matrix:

--- a/sphericart-jax/pyproject.toml
+++ b/sphericart-jax/pyproject.toml
@@ -3,7 +3,7 @@ name = "sphericart-jax"
 dynamic = ["version"]
 requires-python = ">=3.9"
 dependencies = [
-    "jax >= 0.4.18",
+    "jax >=0.4.18 <0.5",
     "packaging",
 ]
 

--- a/sphericart-jax/pyproject.toml
+++ b/sphericart-jax/pyproject.toml
@@ -3,7 +3,7 @@ name = "sphericart-jax"
 dynamic = ["version"]
 requires-python = ">=3.9"
 dependencies = [
-    "jax >=0.4.18 <0.5",
+    "jax >=0.4.18,<0.5",
     "packaging",
 ]
 

--- a/sphericart-jax/pyproject.toml
+++ b/sphericart-jax/pyproject.toml
@@ -3,7 +3,7 @@ name = "sphericart-jax"
 dynamic = ["version"]
 requires-python = ">=3.9"
 dependencies = [
-    "jax >=0.4.18,<0.5",
+    "jax >=0.4.18,<0.6",
     "packaging",
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -84,7 +84,7 @@ commands =
 
     # Install this one manually. Listing it in the deps list above does not install jaxlib.
     # Note: jax[cuda12] is not available on Windows and MacOS.
-    bash -c 'command -v nvcc && python -m pip install -U "jax[cuda12]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html || python -m pip install -U jax[cpu]'
+    bash -c 'command -v nvcc && python -m pip install -U "jax[cuda12]<0.6" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html || python -m pip install -U "jax[cpu]<0.6"'
 
     pip install {[testenv]pip_install_flags} .
     pytest python
@@ -108,7 +108,7 @@ passenv=
 commands =
     # Install this one manually. Listing it in the deps list above does not install jaxlib.
     # Note: jax[cuda12] is not available on Windows and MacOS.
-    bash -c 'command -v nvcc && python -m pip install -U "jax[cuda12]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html || python -m pip install -U jax[cpu]'
+    bash -c 'command -v nvcc && python -m pip install -U "jax[cuda12]<0.6" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html || python -m pip install -U "jax[cpu]<0.6"'
 
     pip install {[testenv]pip_install_flags} .
     pip install {[testenv]pip_install_flags} ./sphericart-torch


### PR DESCRIPTION
Ubuntu 20.04 is deprecated on GH actions, plus our tests were using a mix of 20.04 and 22.04, now it's all 22.04