### PR TITLE
[CI] Ensure torch tests with tox use CUDA

### DIFF
--- a/ci/containers/Containerfile
+++ b/ci/containers/Containerfile
@@ -1,0 +1,10 @@
+FROM docker://nvidia/cuda:12.8.1-cudnn-devel-ubuntu24.04
+
+ENV PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cu128
+ENV CUDA_HOME="/usr/local/cuda"
+
+RUN apt update && apt install -y python3 python3-pip python3-venv git cmake && apt clean
+
+RUN python3 -m pip install --break-system-packages tox torch
+
+ENV Torch_DIR=/usr/local/lib/python3.12/dist-packages/torch/share/cmake/Torch/

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -2,28 +2,38 @@ include:
   - remote: 'https://gitlab.com/cscs-ci/recipes/-/raw/master/templates/v2/.ci-ext.yml'
 
 stages:
+  - build
   - test
 
-test_job:
+build:
+  stage: build
+  extends: .container-builder-cscs-gh200
+  before_script:
+    - TAG_DOCKERFILE=`sha256sum $DOCKERFILE | head -c 8`
+    - TAG=${TAG_DOCKERFILE}
+    - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/base/mtt-base:$TAG
+    - echo "BASE_IMAGE=$PERSIST_IMAGE_NAME" > build.env
+    - 'echo "INFO: Building image $PERSIST_IMAGE_NAME"'
+  artifacts:
+    reports:
+      dotenv: build.env
+  variables:
+    DOCKERFILE: ci/containers/Containerfile
+
+test:
   stage: test
   extends: .container-runner-daint-gh200
-  image: nvcr.io/nvidia/pytorch:24.12-py3
-  timeout: 2h
+  image: $BASE_IMAGE
+  timeout: 1h
   script:
-    - export CUDA_HOME="/usr/local/cuda"
-    - python3 -m pip install --upgrade pip
-    - python3 -m pip install tox
-    - tox
-    - export Torch_DIR=/usr/local/lib/python3.12/dist-packages/torch/share/cmake/Torch/
+    - tox -r
     - mkdir buildcpp
-    - cd buildcpp
-    - cmake .. -DSPHERICART_BUILD_TESTS=ON -DSPHERICART_OPENMP=ON -DSPHERICART_BUILD_EXAMPLES=ON -DSPHERICART_ENABLE_CUDA=ON -DSPHERICART_BUILD_TORCH=ON
-    - cmake --build . --parallel
-    - ctest
-
+    - cmake -B buildcpp -S . -DSPHERICART_BUILD_TESTS=ON -DSPHERICART_OPENMP=ON -DSPHERICART_BUILD_EXAMPLES=ON -DSPHERICART_ENABLE_CUDA=ON -DSPHERICART_BUILD_TORCH=ON
+    - cmake --build buildcpp --parallel
+    - ctest --test-dir buildcpp --output-on-failure
   variables:
     SLURM_JOB_NUM_NODES: 1
     SLURM_PARTITION: normal
     SLURM_NTASKS: 1
-    SLURM_TIMELIMIT: '02:30:00'
+    SLURM_TIMELIMIT: '00:30:00'
     GIT_STRATEGY: fetch

--- a/python/tests/test_vs_scipy.py
+++ b/python/tests/test_vs_scipy.py
@@ -14,10 +14,10 @@ def scipy_real_sph(xyz, l, m):  # noqa E741
     y = xyz[:, 1]
     z = xyz[:, 2]
     r = np.sqrt(x**2 + y**2 + z**2)
-    theta = np.arccos(z / r)
-    phi = np.arctan2(y, x)
-    complex_sh_scipy_l_m = scipy.special.sph_harm(m, l, phi, theta)
-    complex_sh_scipy_l_negm = scipy.special.sph_harm(-m, l, phi, theta)
+    phi = np.arccos(z / r)
+    theta = np.arctan2(y, x)
+    complex_sh_scipy_l_m = scipy.special.sph_harm_y(l, m, phi, theta)
+    complex_sh_scipy_l_negm = scipy.special.sph_harm_y(l, -m, phi, theta)
 
     if m > 0:
         sh_scipy_l_m = (

--- a/sphericart-jax/pyproject.toml
+++ b/sphericart-jax/pyproject.toml
@@ -3,7 +3,7 @@ name = "sphericart-jax"
 dynamic = ["version"]
 requires-python = ">=3.9"
 dependencies = [
-    "jax >=0.4.18,<0.6",
+    "jax >=0.4.18,<0.8",
     "packaging",
 ]
 

--- a/sphericart-jax/python/sphericart/jax/__init__.py
+++ b/sphericart-jax/python/sphericart/jax/__init__.py
@@ -44,7 +44,7 @@ def get_minimum_cuda_version_for_jax(jax_version):
 
 # register the operations to xla
 for _name, _value in sphericart_jax_cpu.registrations().items():
-    jax.lib.xla_client.register_custom_call_target(_name, _value, platform="cpu")
+    jax.ffi.register_ffi_target(_name, _value, platform="cpu", api_version=0)
 
 has_sphericart_jax_cuda = False
 try:
@@ -53,7 +53,7 @@ try:
     has_sphericart_jax_cuda = True
     # register the operations to xla
     for _name, _value in sphericart_jax_cuda.registrations().items():
-        jax.lib.xla_client.register_custom_call_target(_name, _value, platform="gpu")
+        jax.ffi.register_ffi_target(_name, _value, platform="gpu", api_version=0)
 except ImportError:
     has_sphericart_jax_cuda = False
     pass

--- a/sphericart-jax/python/sphericart/jax/ddsph.py
+++ b/sphericart-jax/python/sphericart/jax/ddsph.py
@@ -2,7 +2,7 @@ import math
 from functools import partial
 
 import jax
-from jax import core
+from jax import extend
 from jax.core import ShapedArray
 from jax.interpreters import mlir, xla
 from jax.interpreters.mlir import custom_call, ir
@@ -14,7 +14,7 @@ from .utils import build_sph_descriptor, default_layouts
 # as well as some transformation rules. For more information and comments,
 # see sph.py
 
-_ddsph_p = core.Primitive("ddsph")
+_ddsph_p = extend.core.Primitive("ddsph")
 _ddsph_p.multiple_results = True
 _ddsph_p.def_impl(partial(xla.apply_primitive, _ddsph_p))
 

--- a/sphericart-jax/python/sphericart/jax/dsph.py
+++ b/sphericart-jax/python/sphericart/jax/dsph.py
@@ -3,7 +3,7 @@ from functools import partial
 
 import jax
 import jax.numpy as jnp
-from jax import core
+from jax import extend
 from jax.core import ShapedArray
 from jax.interpreters import ad, mlir, xla
 from jax.interpreters.mlir import custom_call, ir
@@ -16,7 +16,7 @@ from .utils import build_sph_descriptor, default_layouts
 # as well as some transformation rules. For more information and comments,
 # see sph.py
 
-_dsph_p = core.Primitive("dsph")
+_dsph_p = extend.core.Primitive("dsph")
 _dsph_p.multiple_results = True
 _dsph_p.def_impl(partial(xla.apply_primitive, _dsph_p))
 

--- a/sphericart-jax/python/sphericart/jax/sph.py
+++ b/sphericart-jax/python/sphericart/jax/sph.py
@@ -3,7 +3,7 @@ from functools import partial
 
 import jax
 import jax.numpy as jnp
-from jax import core
+from jax import extend
 from jax.core import ShapedArray
 from jax.interpreters import ad, mlir, xla
 from jax.interpreters.mlir import custom_call, ir
@@ -13,7 +13,7 @@ from .utils import build_sph_descriptor, default_layouts
 
 
 # register the sph primitive
-_sph_p = core.Primitive("sph_fwd")
+_sph_p = extend.core.Primitive("sph_fwd")
 _sph_p.def_impl(partial(xla.apply_primitive, _sph_p))
 
 

--- a/sphericart-jax/python/tests/test_pure_jax.py
+++ b/sphericart-jax/python/tests/test_pure_jax.py
@@ -2,6 +2,7 @@ import jax
 import jax.numpy as jnp
 import pytest
 from pure_jax_sph import pure_jax_spherical_harmonics
+from utils import jax_float64
 
 import sphericart.jax
 
@@ -14,12 +15,12 @@ def xyz():
 
 @pytest.mark.parametrize("l_max", [2, 7])
 def test_jit(xyz, l_max):
-    jax.config.update("jax_enable_x64", True)
-    jitted_sph = jax.jit(sphericart.jax.spherical_harmonics, static_argnums=(1,))
-    pure_jax_jitted_sph = jax.jit(pure_jax_spherical_harmonics, static_argnums=1)
-    sph = jitted_sph(xyz=xyz, l_max=l_max)
-    sph_pure_jax = pure_jax_jitted_sph(xyz, l_max)
-    assert jnp.allclose(sph, sph_pure_jax, atol=1e-5, rtol=1e-4)
+    with jax_float64():
+        jitted_sph = jax.jit(sphericart.jax.spherical_harmonics, static_argnums=(1,))
+        pure_jax_jitted_sph = jax.jit(pure_jax_spherical_harmonics, static_argnums=1)
+        sph = jitted_sph(xyz=xyz, l_max=l_max)
+        sph_pure_jax = pure_jax_jitted_sph(xyz, l_max)
+        assert jnp.allclose(sph, sph_pure_jax, atol=1e-5, rtol=1e-4)
 
 
 @pytest.mark.parametrize("l_max", [2, 7])

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ deps =
     cmake
 
     numpy
-    scipy
+    scipy>1.14
     pytest
     metatensor
 
@@ -84,7 +84,7 @@ commands =
 
     # Install this one manually. Listing it in the deps list above does not install jaxlib.
     # Note: jax[cuda12] is not available on Windows and MacOS.
-    bash -c 'command -v nvcc && python -m pip install -U "jax[cuda12]<0.6" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html || python -m pip install -U "jax[cpu]<0.6"'
+    bash -c 'command -v nvcc && python -m pip install -U "jax[cuda12]<0.8" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html || python -m pip install -U "jax[cpu]<0.8"'
 
     pip install {[testenv]pip_install_flags} .
     pytest python
@@ -108,7 +108,7 @@ passenv=
 commands =
     # Install this one manually. Listing it in the deps list above does not install jaxlib.
     # Note: jax[cuda12] is not available on Windows and MacOS.
-    bash -c 'command -v nvcc && python -m pip install -U "jax[cuda12]<0.6" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html || python -m pip install -U "jax[cpu]<0.6"'
+    bash -c 'command -v nvcc && python -m pip install -U "jax[cuda12]<0.8" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html || python -m pip install -U "jax[cpu]<0.8"'
 
     pip install {[testenv]pip_install_flags} .
     pip install {[testenv]pip_install_flags} ./sphericart-torch


### PR DESCRIPTION
PR https://github.com/lab-cosmo/sphericart/pull/176 introduced the necessary change to run CI on Alps. However, `torch`-based tests were running on the CPU because of the lack of the appropriate wheels. This PR ensures that a CUDA-enabled version of PyTorch is installed:
```
torch-tests: cmake==4.0.3,e3nn==0.5.6,filelock==3.18.0,fsspec==2025.7.0,iniconfig==2.1.0,Jinja2==3.1.6,MarkupSafe==3.0.2,metatensor-core==0.1.15,metatensor-torch==0.7.6,mpmath==1.3.0,networkx==3.5,numpy==2.3.2,opt-einsum-fx==0.1.4,opt_einsum==3.4.0,packaging==25.0,pip==25.1.1,pluggy==1.6.0,Pygments==2.19.2,pytest==8.4.1,scipy==1.16.1,setuptools==80.9.0,sympy==1.14.0,torch==2.7.1+cu128,triton==3.3.1,typing_extensions==4.14.1,vesin==0.3.7,wheel==0.45.1
```

Additionally, the PR introduces the necessary changes to run with JAX (`0.6` and the recently released `0.7`), and removes some deprecation warnings with the latest version of `scipy`. I know very little about JAX, so please double check the changes carefully. 

* [ ] Check the minimum version of JAX needed