### PR TITLE
CSCS Compatibility

### DIFF
--- a/sphericart-torch/CMakeLists.txt
+++ b/sphericart-torch/CMakeLists.txt
@@ -72,32 +72,32 @@ if (SPHERICART_TORCH_BUILD_FOR_PYTHON)
     set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake;${CMAKE_MODULE_PATH}")
 
     # First try using the `nvidia.cudnn` package (dependency of torch on PyPI)
-    execute_process(
-        COMMAND ${PYTHON_EXECUTABLE} -c "import nvidia.cudnn, os; print(os.path.dirname(nvidia.cudnn.__file__))"
-        RESULT_VARIABLE CUDNN_CMAKE_PATH_RESULT
-        OUTPUT_VARIABLE CUDNN_CMAKE_PATH_OUTPUT
-        ERROR_VARIABLE CUDNN_CMAKE_PATH_ERROR
-    )
-    if (${CUDNN_CMAKE_PATH_RESULT} EQUAL 0)
-        string(STRIP ${CUDNN_CMAKE_PATH_OUTPUT} CUDNN_CMAKE_PATH_OUTPUT)
-        set(CUDNN_ROOT ${CUDNN_CMAKE_PATH_OUTPUT})
-    else()
-        # Otherwise try to find CuDNN inside PyTorch itself
-        set(CUDNN_ROOT ${TORCH_CMAKE_PATH_OUTPUT}/../..)
+    # execute_process(
+    #     COMMAND ${PYTHON_EXECUTABLE} -c "import nvidia.cudnn, os; print(os.path.dirname(nvidia.cudnn.__file__))"
+    #     RESULT_VARIABLE CUDNN_CMAKE_PATH_RESULT
+    #     OUTPUT_VARIABLE CUDNN_CMAKE_PATH_OUTPUT
+    #     ERROR_VARIABLE CUDNN_CMAKE_PATH_ERROR
+    # )
+    # if (${CUDNN_CMAKE_PATH_RESULT} EQUAL 0)
+    #     string(STRIP ${CUDNN_CMAKE_PATH_OUTPUT} CUDNN_CMAKE_PATH_OUTPUT)
+    #     set(CUDNN_ROOT ${CUDNN_CMAKE_PATH_OUTPUT})
+    # else()
+    #     # Otherwise try to find CuDNN inside PyTorch itself
+    #     set(CUDNN_ROOT ${TORCH_CMAKE_PATH_OUTPUT}/../..)
 
-        if (NOT EXISTS ${CUDNN_ROOT}/include/cudnn_version.h)
-            # HACK: create a minimal cudnn_version.h (with a made-up version),
-            # because it is not bundled together with the CuDNN shared library
-            # in PyTorch: https://github.com/pytorch/pytorch/issues/47743
-            file(WRITE ${CUDNN_ROOT}/include/cudnn_version.h "#define CUDNN_MAJOR 8\n#define CUDNN_MINOR 5\n#define CUDNN_PATCHLEVEL 0\n")
-        endif()
-    endif()
+    #     if (NOT EXISTS ${CUDNN_ROOT}/include/cudnn_version.h)
+    #         # HACK: create a minimal cudnn_version.h (with a made-up version),
+    #         # because it is not bundled together with the CuDNN shared library
+    #         # in PyTorch: https://github.com/pytorch/pytorch/issues/47743
+    #         file(WRITE ${CUDNN_ROOT}/include/cudnn_version.h "#define CUDNN_MAJOR 8\n#define CUDNN_MINOR 5\n#define CUDNN_PATCHLEVEL 0\n")
+    #     endif()
+    # endif()
 
-    set(CUDNN_INCLUDE_DIR ${CUDNN_ROOT}/include CACHE PATH "" FORCE)
-    set(CUDNN_LIBRARY ${CUDNN_ROOT}/lib CACHE PATH "" FORCE)
-    unset(CUDNN_ROOT)
+    # set(CUDNN_INCLUDE_DIR ${CUDNN_ROOT}/include CACHE PATH "" FORCE)
+    # set(CUDNN_LIBRARY ${CUDNN_ROOT}/lib CACHE PATH "" FORCE)
+    # unset(CUDNN_ROOT)
 
-    mark_as_advanced(CUDNN_INCLUDE_DIR CUDNN_LIBRARY)
+    # mark_as_advanced(CUDNN_INCLUDE_DIR CUDNN_LIBRARY)
 else()
     if (NOT TARGET sphericart)
         message(FATAL_ERROR "missing sphericart target, you should build sphericart_torch as a sub-project of sphericart")

--- a/sphericart-torch/CMakeLists.txt
+++ b/sphericart-torch/CMakeLists.txt
@@ -64,40 +64,6 @@ if (SPHERICART_TORCH_BUILD_FOR_PYTHON)
 
     string(STRIP ${TORCH_CMAKE_PATH_OUTPUT} TORCH_CMAKE_PATH_OUTPUT)
     set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};${TORCH_CMAKE_PATH_OUTPUT}")
-
-    # ============================= Handle CUDNN ============================= #
-    # The FindCUDNN.cmake distributed with PyTorch is a bit broken, so we have a
-    # fixed version in `cmake/FindCUDNN.cmake`, and we set the right variables
-    # for it below to point the code to the right `libcudnn.do`/`cudnn.h`
-    set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake;${CMAKE_MODULE_PATH}")
-
-    # First try using the `nvidia.cudnn` package (dependency of torch on PyPI)
-    # execute_process(
-    #     COMMAND ${PYTHON_EXECUTABLE} -c "import nvidia.cudnn, os; print(os.path.dirname(nvidia.cudnn.__file__))"
-    #     RESULT_VARIABLE CUDNN_CMAKE_PATH_RESULT
-    #     OUTPUT_VARIABLE CUDNN_CMAKE_PATH_OUTPUT
-    #     ERROR_VARIABLE CUDNN_CMAKE_PATH_ERROR
-    # )
-    # if (${CUDNN_CMAKE_PATH_RESULT} EQUAL 0)
-    #     string(STRIP ${CUDNN_CMAKE_PATH_OUTPUT} CUDNN_CMAKE_PATH_OUTPUT)
-    #     set(CUDNN_ROOT ${CUDNN_CMAKE_PATH_OUTPUT})
-    # else()
-    #     # Otherwise try to find CuDNN inside PyTorch itself
-    #     set(CUDNN_ROOT ${TORCH_CMAKE_PATH_OUTPUT}/../..)
-
-    #     if (NOT EXISTS ${CUDNN_ROOT}/include/cudnn_version.h)
-    #         # HACK: create a minimal cudnn_version.h (with a made-up version),
-    #         # because it is not bundled together with the CuDNN shared library
-    #         # in PyTorch: https://github.com/pytorch/pytorch/issues/47743
-    #         file(WRITE ${CUDNN_ROOT}/include/cudnn_version.h "#define CUDNN_MAJOR 8\n#define CUDNN_MINOR 5\n#define CUDNN_PATCHLEVEL 0\n")
-    #     endif()
-    # endif()
-
-    # set(CUDNN_INCLUDE_DIR ${CUDNN_ROOT}/include CACHE PATH "" FORCE)
-    # set(CUDNN_LIBRARY ${CUDNN_ROOT}/lib CACHE PATH "" FORCE)
-    # unset(CUDNN_ROOT)
-
-    # mark_as_advanced(CUDNN_INCLUDE_DIR CUDNN_LIBRARY)
 else()
     if (NOT TARGET sphericart)
         message(FATAL_ERROR "missing sphericart target, you should build sphericart_torch as a sub-project of sphericart")

--- a/sphericart/include/cuda_cache.hpp
+++ b/sphericart/include/cuda_cache.hpp
@@ -275,8 +275,6 @@ class CachedKernel {
         int arch = major * 10 + minor;
         std::string smbuf = "--gpu-architecture=sm_" + std::to_string(arch);
 
-        std::cout << "GPU ARCH: " << smbuf << std::endl;
-
         c_options.push_back(smbuf.c_str());
 
         nvrtcResult compileResult =
@@ -299,8 +297,7 @@ class CachedKernel {
 
         // load the module from cubin
         CUmodule module = nullptr;
-        CUresult cuResult =
-            CUDA_DRIVER_INSTANCE.cuModuleLoadDataEx(&module, cubin.data(), 0, 0, 0);
+        CUresult cuResult = CUDA_DRIVER_INSTANCE.cuModuleLoadDataEx(&module, cubin.data(), 0, 0, 0);
 
         if (cuResult != CUDA_SUCCESS) {
             throw std::runtime_error(

--- a/sphericart/include/cuda_cache.hpp
+++ b/sphericart/include/cuda_cache.hpp
@@ -274,6 +274,9 @@ class CachedKernel {
         ));
         int arch = major * 10 + minor;
         std::string smbuf = "--gpu-architecture=sm_" + std::to_string(arch);
+
+        std::cout << "GPU ARCH: " << smbuf << std::endl;
+
         c_options.push_back(smbuf.c_str());
 
         nvrtcResult compileResult =
@@ -288,16 +291,16 @@ class CachedKernel {
             );
         }
 
-        // Get PTX code
-        size_t ptxSize;
-        NVRTC_SAFE_CALL(NVRTC_INSTANCE.nvrtcGetPTXSize(prog, &ptxSize));
-        std::vector<char> ptxCode(ptxSize);
-        NVRTC_SAFE_CALL(NVRTC_INSTANCE.nvrtcGetPTX(prog, ptxCode.data()));
+        // fetch CUBIN
+        size_t cubinSize = 0;
+        NVRTC_SAFE_CALL(NVRTC_INSTANCE.nvrtcGetCUBINSize(prog, &cubinSize));
+        std::vector<char> cubin(cubinSize);
+        NVRTC_SAFE_CALL(NVRTC_INSTANCE.nvrtcGetCUBIN(prog, cubin.data()));
 
-        CUmodule module;
-
+        // load the module from cubin
+        CUmodule module = nullptr;
         CUresult cuResult =
-            CUDA_DRIVER_INSTANCE.cuModuleLoadDataEx(&module, ptxCode.data(), 0, 0, 0);
+            CUDA_DRIVER_INSTANCE.cuModuleLoadDataEx(&module, cubin.data(), 0, 0, 0);
 
         if (cuResult != CUDA_SUCCESS) {
             throw std::runtime_error(

--- a/sphericart/include/dynamic_cuda.hpp
+++ b/sphericart/include/dynamic_cuda.hpp
@@ -296,6 +296,8 @@ class NVRTC {
     using nvrtcCompileProgram_t = nvrtcResult (*)(nvrtcProgram, int, const char*[]);
     using nvrtcGetPTX_t = nvrtcResult (*)(nvrtcProgram, char*);
     using nvrtcGetPTXSize_t = nvrtcResult (*)(nvrtcProgram, size_t*);
+    using nvrtcGetCUBIN_t = nvrtcResult (*) (nvrtcProgram, char*);
+    using nvrtcGetCUBINSize_t = nvrtcResult (*) (nvrtcProgram, size_t*);
     using nvrtcGetProgramLog_t = nvrtcResult (*)(nvrtcProgram, char*);
     using nvrtcGetProgramLogSize_t = nvrtcResult (*)(nvrtcProgram, size_t*);
     using nvrtcAddNameExpression_t = nvrtcResult (*)(nvrtcProgram, const char* const);
@@ -307,6 +309,8 @@ class NVRTC {
     nvrtcCompileProgram_t nvrtcCompileProgram;
     nvrtcGetPTX_t nvrtcGetPTX;
     nvrtcGetPTXSize_t nvrtcGetPTXSize;
+    nvrtcGetCUBIN_t nvrtcGetCUBIN;
+    nvrtcGetCUBINSize_t nvrtcGetCUBINSize;
     nvrtcGetProgramLog_t nvrtcGetProgramLog;
     nvrtcGetProgramLogSize_t nvrtcGetProgramLogSize;
     nvrtcGetLoweredName_t nvrtcGetLoweredName;
@@ -327,6 +331,8 @@ class NVRTC {
             nvrtcCompileProgram = load<nvrtcCompileProgram_t>(nvrtcHandle, "nvrtcCompileProgram");
             nvrtcGetPTX = load<nvrtcGetPTX_t>(nvrtcHandle, "nvrtcGetPTX");
             nvrtcGetPTXSize = load<nvrtcGetPTXSize_t>(nvrtcHandle, "nvrtcGetPTXSize");
+            nvrtcGetCUBIN = load<nvrtcGetCUBIN_t>(nvrtcHandle, "nvrtcGetCUBIN");
+            nvrtcGetCUBINSize = load <nvrtcGetCUBINSize_t> (nvrtcHandle, "nvrtcGetCUBINSize");
             nvrtcGetProgramLog = load<nvrtcGetProgramLog_t>(nvrtcHandle, "nvrtcGetProgramLog");
             nvrtcGetProgramLogSize =
                 load<nvrtcGetProgramLogSize_t>(nvrtcHandle, "nvrtcGetProgramLogSize");

--- a/sphericart/include/dynamic_cuda.hpp
+++ b/sphericart/include/dynamic_cuda.hpp
@@ -296,8 +296,8 @@ class NVRTC {
     using nvrtcCompileProgram_t = nvrtcResult (*)(nvrtcProgram, int, const char*[]);
     using nvrtcGetPTX_t = nvrtcResult (*)(nvrtcProgram, char*);
     using nvrtcGetPTXSize_t = nvrtcResult (*)(nvrtcProgram, size_t*);
-    using nvrtcGetCUBIN_t = nvrtcResult (*) (nvrtcProgram, char*);
-    using nvrtcGetCUBINSize_t = nvrtcResult (*) (nvrtcProgram, size_t*);
+    using nvrtcGetCUBIN_t = nvrtcResult (*)(nvrtcProgram, char*);
+    using nvrtcGetCUBINSize_t = nvrtcResult (*)(nvrtcProgram, size_t*);
     using nvrtcGetProgramLog_t = nvrtcResult (*)(nvrtcProgram, char*);
     using nvrtcGetProgramLogSize_t = nvrtcResult (*)(nvrtcProgram, size_t*);
     using nvrtcAddNameExpression_t = nvrtcResult (*)(nvrtcProgram, const char* const);
@@ -332,7 +332,7 @@ class NVRTC {
             nvrtcGetPTX = load<nvrtcGetPTX_t>(nvrtcHandle, "nvrtcGetPTX");
             nvrtcGetPTXSize = load<nvrtcGetPTXSize_t>(nvrtcHandle, "nvrtcGetPTXSize");
             nvrtcGetCUBIN = load<nvrtcGetCUBIN_t>(nvrtcHandle, "nvrtcGetCUBIN");
-            nvrtcGetCUBINSize = load <nvrtcGetCUBINSize_t> (nvrtcHandle, "nvrtcGetCUBINSize");
+            nvrtcGetCUBINSize = load<nvrtcGetCUBINSize_t>(nvrtcHandle, "nvrtcGetCUBINSize");
             nvrtcGetProgramLog = load<nvrtcGetProgramLog_t>(nvrtcHandle, "nvrtcGetProgramLog");
             nvrtcGetProgramLogSize =
                 load<nvrtcGetProgramLogSize_t>(nvrtcHandle, "nvrtcGetProgramLogSize");


### PR DESCRIPTION
This PR fixes two things:

- when there is a cuda driver mismatch on the system vs. what sphericart has been compiled with. For example when the driver max supported toolkit is 12.4, but code has been compiled with 12.6. Fix here is to write cubin code with NVRTC directly, rather than writing PTX and having NVRTC attempt to jit-compile it to SASS.

- removed the cudnn hack so things work in write-disabled environments. Our wheels support at minimum pytorch 2.4 so I think this is fine.