### PR TITLE
Fix the docs build by making sure to create wheels compatible with the environment

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,8 +8,6 @@ version: 2
 # Set the version of Python and other tools we need
 build:
   os: ubuntu-22.04
-  apt_packages:
-    - cmake
   tools:
     python: "3.12"
   jobs:
@@ -17,8 +15,9 @@ build:
     # we can not use the `python` section below since it does not allow
     # to specify `--extra-index-url`
     post_install:
-      - python -m pip install --extra-index-url https://download.pytorch.org/whl/cpu ./sphericart-torch
-      - python -m pip install ./sphericart-jax
+      - python -m pip install --force-reinstall --extra-index-url https://download.pytorch.org/whl/cpu cmake torch pybind11
+      - python -m pip install --no-deps --no-build-isolation --check-build-dependencies ./sphericart-torch
+      - python -m pip install --no-deps --no-build-isolation --check-build-dependencies ./sphericart-jax
 
 # Declare the Python requirements required to build the docs
 python:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,12 +1,14 @@
 # sphinx dependencies
 sphinx
-sphinx_rtd_theme   # sphinx theme
 breathe >=4.33     # C and C++ => sphinx through doxygen
 furo               # sphinx theme
 
+numpy
+torch
+
 # jax[cpu], because python -m pip install jax, which would be triggered
 # by the main package's dependencies, does not install jaxlib
-jax[cpu] >= 0.4.18
+jax[cpu] <0.6
 
 # metatensor and metatensor-torch for the metatensor API
 metatensor-torch

--- a/tox.ini
+++ b/tox.ini
@@ -21,14 +21,16 @@ allowlist_externals =
 
 pip_install_flags = --no-deps --no-cache --no-build-isolation --check-build-dependencies --force-reinstall
 lint_folders = python setup.py sphericart-torch/python sphericart-torch/setup.py sphericart-jax/python sphericart-jax/setup.py
+packaging_deps =
+    wheel
+    setuptools
+    cmake
 
 [testenv:tests]
 # this environement runs Python tests
 
 deps =
-    wheel
-    setuptools
-    cmake
+    {[testenv]packaging_deps}
 
     numpy
     scipy
@@ -43,9 +45,7 @@ commands =
 [testenv:torch-tests]
 # this environement runs tests for the torch bindings
 deps =
-    wheel
-    setuptools
-    cmake
+    {[testenv]packaging_deps}
 
     numpy
     torch
@@ -64,9 +64,7 @@ commands =
 [testenv:jax-tests]
 # this environement runs tests for the jax bindings
 deps =
-    wheel
-    setuptools
-    cmake
+    {[testenv]packaging_deps}
     pybind11
 
     numpy
@@ -93,15 +91,13 @@ commands =
 [testenv:examples]
 # this environement runs the examples for Python and Pytorch bindings
 deps =
-    wheel
-    setuptools
-    cmake
+    {[testenv]packaging_deps}
     pybind11
 
     numpy
     torch
     pytest
-    metatensor
+    metatensor-torch
 
 passenv=
     PIP_EXTRA_INDEX_URL
@@ -208,13 +204,19 @@ commands =
 [testenv:docs]
 # this environement builds the documentation with sphinx
 deps =
+    {[testenv]packaging_deps}
+    pybind11
+
     -r docs/requirements.txt
 
 passenv =
     PIP_EXTRA_INDEX_URL
 
 commands =
-    pip install .[torch,jax]
+    pip install {[testenv]pip_install_flags} .
+    pip install {[testenv]pip_install_flags} ./sphericart-jax
+    pip install {[testenv]pip_install_flags} ./sphericart-torch
+
     sphinx-build {posargs:-E} -W -b html docs/src docs/build/html
 
 [testenv:docs-tests]
@@ -222,8 +224,14 @@ commands =
 deps =
     pytest
 
+    {[testenv]packaging_deps}
+
+    numpy
+    torch
+
 commands =
-    pip install .[torch]
+    pip install {[testenv]pip_install_flags} .
+    pip install {[testenv]pip_install_flags} ./sphericart-torch
     pytest --doctest-modules --pyargs sphericart
 
 [flake8]


### PR DESCRIPTION
Basically always building with `--no-build-isolation` when building in tox