### PR TITLE
Update build: bdist_wheel now lives in setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,8 @@ import uuid
 
 from setuptools import Extension, setup
 from setuptools.command.bdist_egg import bdist_egg
+from setuptools.command.bdist_wheel import bdist_wheel
 from setuptools.command.build_ext import build_ext
-from wheel.bdist_wheel import bdist_wheel
 
 
 ROOT = os.path.realpath(os.path.dirname(__file__))

--- a/sphericart-jax/pyproject.toml
+++ b/sphericart-jax/pyproject.toml
@@ -37,10 +37,7 @@ repository = "https://github.com/lab-cosmo/sphericart"
 ### ======================================================================== ###
 
 [build-system]
-requires = [
-    "setuptools >=77",
-    "wheel >=0.36",
-]
+requires = ["setuptools >=77"]
 # use a custom build backend to add a dependency on jax/cmake only when
 # building wheels
 build-backend = "backend"

--- a/sphericart-torch/pyproject.toml
+++ b/sphericart-torch/pyproject.toml
@@ -38,7 +38,6 @@ repository = "https://github.com/lab-cosmo/sphericart"
 [build-system]
 requires = [
     "setuptools >=77",
-    "wheel >=0.36",
     "cmake >=3.30",
 ]
 # use a custom build backend to add a dependency on torch/cmake only when

--- a/sphericart-torch/setup.py
+++ b/sphericart-torch/setup.py
@@ -4,8 +4,8 @@ import sys
 
 from setuptools import Extension, setup
 from setuptools.command.bdist_egg import bdist_egg
+from setuptools.command.bdist_wheel import bdist_wheel
 from setuptools.command.build_ext import build_ext
-from wheel.bdist_wheel import bdist_wheel
 
 
 ROOT = os.path.realpath(os.path.dirname(__file__))


### PR DESCRIPTION
This is just a warning for now, but the version in wheel will be removed at some point.