### PR TITLE
Spherical harmonics: route batched eval through the SH kernel (#240)

### DIFF
--- a/julia/Project.toml
+++ b/julia/Project.toml
@@ -1,6 +1,6 @@
 name = "SpheriCart"
 uuid = "5caf2b29-02d9-47a3-9434-5931c85ba645"
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/julia/Project.toml
+++ b/julia/Project.toml
@@ -4,7 +4,6 @@ version = "0.3.0"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
-Bumper = "8ce10254-0962-460f-a3d8-1f77fea1446e"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
@@ -24,7 +23,6 @@ ChainRulesCoreExt = "ChainRulesCore"
 [compat]
 ACEbase = "0.4.7"
 BenchmarkTools = "1.6.0"
-Bumper = "0.7.0"
 ChainRulesCore = "1"
 ChainRulesTestUtils = "1"
 ForwardDiff = "0.10, 1.0.1"

--- a/julia/src/SpheriCart.jl
+++ b/julia/src/SpheriCart.jl
@@ -1,6 +1,6 @@
 module SpheriCart
 
-using StaticArrays, Bumper
+using StaticArrays
 
 import LuxCore
 using LuxCore: AbstractLuxLayer

--- a/julia/src/spherical.jl
+++ b/julia/src/spherical.jl
@@ -1,10 +1,10 @@
 
 export SphericalHarmonics
 
-using LinearAlgebra: norm, dot 
+using LinearAlgebra: norm, dot
 
 """
-`struct SphericalHarmonics` : datatype representing a real spherical harmonics basis. 
+`struct SphericalHarmonics` : datatype representing a real spherical harmonics basis.
 
 ### Constructor to generate the basis object
 ```julia
@@ -12,21 +12,21 @@ basis = SphericalHarmonics(L::Integer; kwargs...)
 ```
 
 ### Keyword arguments:
-* `normalisation = :L2` : choose the normalisation of the basis, default is to 
-   make it orthonoormal on the unit sphere. 
+* `normalisation = :L2` : choose the normalisation of the basis, default is to
+   make it orthonoormal on the unit sphere.
 * `static = (L <= 6)` : decide whether single-point evaluation uses fully
 unrolled generated code that outputs an `SVector` (faster for a single input,
 larger compile/stack footprint), or reuses the batched kernel. See
 `SolidHarmonics` for details.
-* `T = Float64` : datatype in which basis parameters are stored. The output type 
-is inferred at runtime, but the rule of thumb is to use `T = FloatX` for 
+* `T = Float64` : datatype in which basis parameters are stored. The output type
+is inferred at runtime, but the rule of thumb is to use `T = FloatX` for
 `FloatX` output.
 
-### Usage example: 
+### Usage example:
 ```julia
 using StaticArrays, SpheriCart
 basis = SphericalHarmonics(4)
-# evaluate basis with single input 
+# evaluate basis with single input
 𝐫 = @SVector randn(3)
 Z = basis(𝐫)
 Z = compute(basis, 𝐫)
@@ -35,7 +35,7 @@ R = [ @SVector randn(3) for _ = 1:32 ]
 Z = basis(Rs)
 Z = compute(basis, Rs)
 
-# to be implented: 
+# to be implented:
 # Z, ∇Z = compute_and_gradients(basis, 𝐫)
 # Z, ∇Z, ∇²Z = compute_and_hessian(basis, 𝐫)
 ```
@@ -45,11 +45,11 @@ struct SphericalHarmonics{L, NORM, STATIC, TF} <: AbstractLuxLayer
    solids::SolidHarmonics{L, NORM, STATIC, TF}
 end
 
-SphericalHarmonics(L::Integer; kwargs...) = 
+SphericalHarmonics(L::Integer; kwargs...) =
       SphericalHarmonics(SolidHarmonics(L; kwargs...))
 
 Base.getproperty(basis::SphericalHarmonics, prop::Symbol) = (
-      prop == :solids ? getfield(basis, :solids) 
+      prop == :solids ? getfield(basis, :solids)
                       : getfield(getfield(basis, :solids), prop) )
 
 @inline (basis::SphericalHarmonics)(args...) = compute(basis, args...)
@@ -74,7 +74,6 @@ end
 # ---------------------
 #  batched api
 
-
 function compute(basis::SphericalHarmonics{L},
                   Rs::AbstractVector{<: SVector{3, T1}},
                   st = (; Flm = basis.Flm)) where {L, T1}
@@ -93,89 +92,22 @@ function compute_with_gradients(basis::SphericalHarmonics{L},
 end
 
 
+# A single KernelAbstractions kernel serves all backends (CPU + GPU) via
+# `get_backend`. The `Val{true}()` selects the spherical path: the inputs are
+# rescaled to the unit sphere and the gradient is projected onto it, in-kernel.
+# (The single-input methods above keep the fast unrolled solid path and do the
+# normalise/project on the host.)
 
-function _normalise_Rs!(rs, Rs_norm,
-                        basis::SphericalHarmonics, 
-                        Rs::AbstractVector{SVector{3, T1}}) where {T1}
-   nX = length(Rs) 
-   @assert length(rs) == length(Rs_norm) == nX
-   @inbounds @simd ivdep for i = 1:nX
-      rs[i] = norm(Rs[i])
-      Rs_norm[i] = Rs[i] / rs[i]
-   end
-   return nothing 
-end
-
-function _rescale_∇Z2∇Y!(∇Z::AbstractMatrix, Rs_norm, rs)
-   nX = length(rs)
-   @inbounds for i = 1:size(∇Z, 2)
-      @simd ivdep for j = 1:nX
-         dzj = ∇Z[j, i] / rs[j]
-         𝐫̂j = Rs_norm[j]
-         ∇Z[j, i] = dzj - dot(𝐫̂j, dzj) * 𝐫̂j
-      end
-   end
-end
-
-
-
-
-function compute!(Y, basis::SphericalHarmonics,
-                  Rs::AbstractVector{<: SVector{3, T1}},
-                  st = (; Flm = basis.Flm)) where {T1}
-   @no_escape begin
-      nX = length(Rs)
-      rs = @alloc(T1, nX)
-      Rs_norm = @alloc(SVector{3, T1}, nX)
-      _normalise_Rs!(rs, Rs_norm, basis, Rs)
-      compute!(Y, basis.solids, Rs_norm, st)
-      nothing
-   end
+function compute!(Y::AbstractMatrix, basis::SphericalHarmonics{L},
+                  Rs::AbstractVector{<: SVector{3}},
+                  st = (; Flm = basis.Flm)) where {L}
+   ka_solid_harmonics!(Y, nothing, Val{L}(), Val{true}(), Rs, st.Flm)
    return Y
 end
 
-
-
-function compute_with_gradients!(Y, ∇Y, basis::SphericalHarmonics,
-                        Rs::AbstractVector{<: SVector{3, T1}},
-                        st = (; Flm = basis.Flm)) where {T1}
-   @no_escape begin
-      nX = length(Rs)
-      rs = @alloc(T1, nX)
-      Rs_norm = @alloc(SVector{3, T1}, nX)
-      _normalise_Rs!(rs, Rs_norm, basis, Rs)
-      compute_with_gradients!(Y, ∇Y, basis.solids, Rs_norm, st)
-      _rescale_∇Z2∇Y!(∇Y, Rs_norm, rs)
-      nothing
-   end
-   return Y, ∇Y
-end
-
-
-# ------------------------------------------
-#  KernelAbstractions in-place api 
-
-using KernelAbstractions
-using GPUArraysCore: AbstractGPUVector, AbstractGPUMatrix
-
-
-function compute!(Y::AbstractGPUMatrix,
-                  basis::SphericalHarmonics{L},
-                  Rs::AbstractGPUVector{<: SVector{3, T1}},
-                  st = (; Flm = basis.Flm)) where {L, T1}
-   # note the Val{true}() means that inputs Rs will be rescaled to unit
-   # length, and the gradient corrected accordingly
-   ka_solid_harmonics!(Y, nothing, Val{L}(), Val{true}(),
-                       Rs, st.Flm)
-   return Y
-end
-
-
-function compute_with_gradients!(Y, ∇Y,
-                  basis::SphericalHarmonics{L},
-                  Rs::AbstractGPUVector{<: SVector{3, T1}},
-                  st = (; Flm = basis.Flm)) where {L, T1}
-   ka_solid_harmonics!(Y, ∇Y, Val{L}(), Val{true}(),
-                       Rs, st.Flm)
+function compute_with_gradients!(Y, ∇Y, basis::SphericalHarmonics{L},
+                  Rs::AbstractVector{<: SVector{3}},
+                  st = (; Flm = basis.Flm)) where {L}
+   ka_solid_harmonics!(Y, ∇Y, Val{L}(), Val{true}(), Rs, st.Flm)
    return Y, ∇Y
 end


### PR DESCRIPTION
## Summary

Addresses #240 (Julia - Code Duplication). The "normalise input onto the unit
sphere → evaluate → project the gradient onto the sphere" logic was implemented in
three places; the **batched-CPU re-implementation** (`_normalise_Rs!` +
`_rescale_∇Z2∇Y!`) duplicated what the KernelAbstractions kernel's `Val{true}`
branch already does.

Now batched `compute!` / `compute_with_gradients!` for `SphericalHarmonics` go
through the **single KA kernel** for **all backends** (`get_backend` picks CPU vs
GPU); the kernel rescales the input and projects the gradient in-kernel.

## Changes

- `src/spherical.jl`: delete `_normalise_Rs!` and `_rescale_∇Z2∇Y!`; collapse the
  separate CPU (Bumper) and GPU `compute!`/`compute_with_gradients!` methods into
  one each that call `ka_solid_harmonics!(..., Val{true}(), ..., st.Flm)`; drop the
  now-unused `KernelAbstractions` / `GPUArraysCore` imports.
- The **single-input** path is unchanged: it keeps the fast unrolled solid kernel
  and does the host-side normalise/project (the only remaining host copy — a
  trivial one-liner, left inline by design rather than abstracted).
- **Bumper** is no longer used anywhere → removed from `[deps]`/`[compat]`.

## Testing

Full `Pkg.test()` passes. `test_sphericalharmonics.jl` exercises single + batched
spherical on the CPU (now routed through the SH kernel) incl. the
orthogonality/ForwardDiff checks; `test_ka.jl` covers GPU spherical on the A100.
Spot-checked batched-vs-single agreement to ~1e-15 (values + gradients).

Closes #240.

🤖 Generated with [Claude Code](https://claude.com/claude-code)