### PR TITLE
Julia: honour the (ps, st) convention in the ACEbase extension

### DIFF
--- a/julia/ext/ACEbaseExt.jl
+++ b/julia/ext/ACEbaseExt.jl
@@ -17,22 +17,30 @@ import ACEbase: evaluate, evaluate_ed, evaluate!, evaluate_ed!, natural_indices
 const Harmonics = Union{SolidHarmonics, SphericalHarmonics,
                         ComplexSolidHarmonics, ComplexSphericalHarmonics}
 
-# allocating interface; the trailing args... swallow optional (ps, st) since
-# the harmonics bases are parameter-free.
-evaluate(basis::Harmonics, x, args...) = compute(basis, x)
+# Two arities are supported throughout:
+#   * `evaluate(basis, x)`          — uses the basis' built-in prefactors;
+#   * `evaluate(basis, x, ps, st)`  — the ACEsuit `(parameters, state)` convention.
+# The bases are parameter-free, so `ps` is ignored, but the *state* carries the
+# `Flm` prefactor matrix and must be forwarded to `compute` (e.g. so that a
+# state with `Float32` prefactors evaluates in `Float32`). The previous
+# `args...`-swallowing methods dropped `st` and always used `basis.Flm`, so the
+# `(ps, st)` calls silently ignored the supplied state.
 
-evaluate_ed(basis::Harmonics, x, args...) = compute_with_gradients(basis, x)
+# allocating interface
+evaluate(basis::Harmonics, x) = compute(basis, x)
+evaluate(basis::Harmonics, x, ps, st) = compute(basis, x, st)
+
+evaluate_ed(basis::Harmonics, x) = compute_with_gradients(basis, x)
+evaluate_ed(basis::Harmonics, x, ps, st) = compute_with_gradients(basis, x, st)
 
 # in-place interface
-function evaluate!(Y, basis::Harmonics, x, args...)
-   compute!(Y, basis, x)
-   return Y
-end
+evaluate!(Y, basis::Harmonics, x) = (compute!(Y, basis, x); Y)
+evaluate!(Y, basis::Harmonics, x, ps, st) = (compute!(Y, basis, x, st); Y)
 
-function evaluate_ed!(Y, dY, basis::Harmonics, x, args...)
-   compute_with_gradients!(Y, dY, basis, x)
-   return Y, dY
-end
+evaluate_ed!(Y, dY, basis::Harmonics, x) =
+      (compute_with_gradients!(Y, dY, basis, x); (Y, dY))
+evaluate_ed!(Y, dY, basis::Harmonics, x, ps, st) =
+      (compute_with_gradients!(Y, dY, basis, x, st); (Y, dY))
 
 # the (l, m) spec, in the order the basis values are stored
 natural_indices(basis::Harmonics) =

--- a/julia/test/test_aceinterface.jl
+++ b/julia/test/test_aceinterface.jl
@@ -84,15 +84,35 @@ end
    for basis in bases
       𝐫 = _rand_sphere()
       R = [ _rand_sphere() for _ = 1:13 ]
+      st = (; Flm = basis.Flm)        # the ACEsuit (parameters, state) convention
+      # 2-arg form
       @test evaluate(basis, 𝐫) == compute(basis, 𝐫)
       @test evaluate(basis, R) == compute(basis, R)
-      @test evaluate(basis, R, nothing, nothing) == compute(basis, R)
       Yc, dYc = compute_with_gradients(basis, R)
       Ye, dYe = evaluate_ed(basis, R)
       @test Yc == Ye && dYc == dYe
-      # in-place
-      Y = similar(compute(basis, R))
+      # `(ps, st)` form forwards the state to `compute`
+      @test evaluate(basis, 𝐫, nothing, st) == compute(basis, 𝐫, st)
+      @test evaluate(basis, R, nothing, st) == compute(basis, R, st)
+      Ye2, dYe2 = evaluate_ed(basis, R, nothing, st)
+      @test Ye2 == Yc && dYe2 == dYc
+      # in-place, both arities
+      Y = similar(compute(basis, R)); dY = similar(dYc)
       @test evaluate!(Y, basis, R) == compute(basis, R)
+      @test evaluate!(Y, basis, R, nothing, st) == compute(basis, R)
+      @test evaluate_ed!(Y, dY, basis, R, nothing, st) == (Yc, dYc)
+   end
+end
+
+@testset "ACEbase interface honours the state" begin
+   # a `Float32` state must produce a `Float32` evaluation through the ACEbase
+   # path (this is exactly what the old `args...` methods silently dropped).
+   for basis in (SolidHarmonics(5), ComplexSolidHarmonics(5))
+      st32 = (; Flm = Float32.(basis.Flm))
+      R32 = [ SVector{3, Float32}(_rand_sphere()...) for _ = 1:13 ]
+      Y32 = evaluate(basis, R32, nothing, st32)
+      @test real(eltype(Y32)) == Float32
+      @test Y32 ≈ compute(basis, R32)  rtol = 1e-4
    end
 end
 


### PR DESCRIPTION
## Problem

The ACEbase extension (`ext/ACEbaseExt.jl`) defined its interface methods with a
trailing `args...` that swallowed the optional `(ps, st)` arguments and always
forwarded to `compute(basis, x)`:

```julia
evaluate(basis::Harmonics, x, args...) = compute(basis, x)
```

So the ACEsuit `(parameters, state)` calling convention — `evaluate(basis, x, ps, st)`
— did not actually work: the supplied **state was silently dropped** and evaluation
always used the basis' built-in `basis.Flm`. A caller passing a custom state (e.g.
`Float32` prefactors) got the default evaluation instead of one driven by their state.

## Fix

Replace the `args...` methods with explicit two-arity methods for `evaluate`,
`evaluate_ed`, `evaluate!`, `evaluate_ed!`:

- `(basis, x)` — keeps the built-in path (`compute(basis, x)`);
- `(basis, x, ps, st)` — forwards the state: `compute(basis, x, st)`. `ps` is ignored
  because the harmonics bases are parameter-free.

This matches the `compute(..., st)` API introduced with the LuxCore layers, so the
state (which carries `Flm`) is honoured end-to-end.

`natural_indices` is unchanged. The Hessian-level ACEbase functions (`evaluate_dd`,
`evaluate_ed2`) are intentionally still not provided — SpheriCart has no second-
derivative path.

## Tests

- `test/test_aceinterface.jl` previously passed `st = nothing`, which masked the bug.
  It now passes a real state, exercises **both** arities (allocating + in-place) for
  all four bases, and adds a testset confirming that a `Float32` state evaluates in
  `Float32` through the ACEbase path.
- Full suite green locally (CPU backend): **1031/1031 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)